### PR TITLE
Fix path of config/set_vars.sh in install docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,12 +62,13 @@ target/
 *.iso
 bin/packer
 packer/output/
-config/aws-credentials
 
 # Private Files
 *.pem
 *.ppk
 vault/private/
+config/aws-credentials
+config/set_vars.sh
 
 # Personal Vagrant files
 .vagrant/

--- a/config/set_vars.sh.example
+++ b/config/set_vars.sh.example
@@ -1,0 +1,5 @@
+export AWS_CREDENTIALS=../config/aws-credentials
+export SSH_KEY=~/.ssh/your-key.pem
+export BASTION_KEY=~/.ssh/microns-bastion20151117.pem
+export BASTION_IP=52.3.13.189
+export BASTION_USER=ubuntu

--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -12,7 +12,7 @@ directory of the cloned boss-manage.git repository.*
 You will need a Linux machine installed with the following software packages:
 * Python 3.5
 * Packer ([download](https://www.packer.io/))
-* Install Python packages in boss-manage.git requirements.txt.  See *Install Procedures* below to install boss-manage.git then run: 
+* Install Python packages in boss-manage.git requirements.txt.  See *Install Procedures* below to install boss-manage.git then run:
 ```shell
 pip install -r requirements.txt
 ```
@@ -173,21 +173,21 @@ The scripts make use of multiple environment variables to manage optional
 configuration elements. There are shell scripts that contain these environment
 variables that can be sourced before launching different scripts.
 
-1. Open `boss-manage.git/vault/set_keys.sh` in a text editor
+1. Open `boss-manage.git/config/set_vars.sh` in a text editor
 2. Update SSH_KEY to contain the location of the EC2 Keypair created
 3. Update the BASTION_KEY to contain the location of the private key of the SSH bastion host
 4. Update the BASTION_IP to contain the IP of the SSH bastion host
-5. Save `set_keys.sh` and close the text editor
+5. Save `set_vars.sh` and close the text editor
 ```shell
 $ cd cloudformation/
-$ source ../vault/set_vars.sh
+$ source ../config/set_vars.sh
 $ source ../scalyr_keys.sh
 ```
 
 ### Setting up Certificates in Amazon Certificates Manage.
-You will need to create certificates for auth and api in the domain 
-(theboss.io) These only needs to be setup once. 
-You will need to create a EC2 instance to route mail.  Create a micro 
+You will need to create certificates for auth and api in the domain
+(theboss.io) These only needs to be setup once.
+You will need to create a EC2 instance to route mail.  Create a micro
 Ubuntu instance.
 Installed postfix and setup theboss.io as a "virtual alias domain"
 sudo apt-get install postfix
@@ -198,7 +198,7 @@ change /etc/postfix/main.cf:
 
 created new file /etc/postfix/virtual:
     administrator@theboss.io	your-email-address
-your-email-address is a valild address that will recieve the request to 
+your-email-address is a valild address that will recieve the request to
 validate that the certicate should be created.
 
 In Route53 create an MX record for theboss.io and add your public instance DNS name to it.
@@ -208,7 +208,7 @@ cd boss-manage/bin/
 python3.5 create_certificate.py api.theboss.io
 python3.5 create_certificate.py auth.theboss.io
 
-After you receive the certificate approval emails, turn off the mail instance. 
+After you receive the certificate approval emails, turn off the mail instance.
 
 
 #### Launching
@@ -240,5 +240,5 @@ sudo python3 manage.py createsuperuser
 sudo python3 manage.py test
 ```
 	output should say 203 Tests OK with 14 skipped tests.
-	
+
 	There are 2 tests that need >2.5GB of memory to run. To run them, set an enviroment variable "RUN_HIGH_MEM_TESTS"

--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -173,6 +173,7 @@ The scripts make use of multiple environment variables to manage optional
 configuration elements. There are shell scripts that contain these environment
 variables that can be sourced before launching different scripts.
 
+0. Copy `config/set_vars.sh.example` to `config/set_vars.sh`
 1. Open `boss-manage.git/config/set_vars.sh` in a text editor
 2. Update SSH_KEY to contain the location of the EC2 Keypair created
 3. Update the BASTION_KEY to contain the location of the private key of the SSH bastion host

--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -143,7 +143,7 @@ few steps below.*
 ### Create EC2 Key Pair
 1. Open a web browser
 2. Login to the AWS console and open up the EC2 console
-3. Select **Key Pairs** from the left side menu
+3. Select [**Key Pairs**](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName) from the left side menu
 4. Click **Create Key Pair**
 5. Name the key pair
 6. Click **Create**

--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -186,21 +186,31 @@ $ source ../scalyr_keys.sh
 ```
 
 ### Setting up Certificates in Amazon Certificates Manage.
-You will need to create certificates for auth and api in the domain
-(theboss.io) These only needs to be setup once.
-You will need to create a EC2 instance to route mail.  Create a micro
-Ubuntu instance.
-Installed postfix and setup theboss.io as a "virtual alias domain"
+You will need to create certificates for auth and api in the domain (theboss.io).
+These only need to be set up once.
+
+You will need to create a EC2 instance to route mail
+
+1. Create a micro Ubuntu instance.
+2. Install postfix and set up theboss.io as a "virtual alias domain"
+
+```shell
 sudo apt-get install postfix
+```
 
-change /etc/postfix/main.cf:
-    virtual_alias_domains = theboss.io
-    virtual_alias_maps = hash:/etc/postfix/virtual
+change `/etc/postfix/main.cf`:
+```
+virtual_alias_domains = theboss.io
+virtual_alias_maps = hash:/etc/postfix/virtual
+```
 
-created new file /etc/postfix/virtual:
-    administrator@theboss.io	your-email-address
-your-email-address is a valild address that will recieve the request to
-validate that the certicate should be created.
+create a new file `/etc/postfix/virtual`:
+```
+administrator@theboss.io	your-email-address
+```
+
+`your-email-address` is a valid address that will receive the request to
+validate that the certificate should be created.
 
 In Route53 create an MX record for theboss.io and add your public instance DNS name to it.
 


### PR DESCRIPTION
The [InstallGuide.md documentation](https://github.com/jhuapl-boss/boss-manage/blob/master/docs/InstallGuide.md#environment-setup) mentions the file `/vault/set_keys.sh`, but it appears not to exist in the git history:

``` shell
$ git log --all -- "**/set_keys*"
```

The guide sources a file `../vault/set_vars.sh` later on, so I looked for that. It was created in [c113ad747](https://github.com/jhuapl-boss/boss-manage/blob/c113ad747ec6b565c29e8476a9b8546254df2d1a/vault/set_vars.sh), but moved in 25816b7052f33ad5e310ab21654861a14a169777 to `config/set_vars.sh`. This updates the documentation to reflect this change.
## Other changes:

• I updated some links in the guide to ease the installation process
• I added `set_vars.sh` to the .gitignore, and added instructions to make your own (to keep keyfile and paths private, and prevent accidental checkin)
