### PR TITLE
Expire ttl policies

### DIFF
--- a/bin/update_lambda_fcn.py
+++ b/bin/update_lambda_fcn.py
@@ -177,6 +177,7 @@ def create_ndingest_settings(domain, fp):
     parser['aws']['cuboid_bucket'] = names.cuboid_bucket
     parser['aws']['tile_index_table'] = names.tile_index
     parser['aws']['cuboid_index_table'] = names.s3_index
+    parser['aws']['max_task_id_suffix'] = str(const.MAX_TASK_ID_SUFFIX)
 
     # parser['spdb']['SUPER_CUBOID_SIZE'] = CUBOIDSIZE[0]
     # ToDo: find way to always get cuboid size from spdb.

--- a/lib/cloudformation.py
+++ b/lib/cloudformation.py
@@ -950,7 +950,7 @@ class CloudFormationConfiguration:
 
         self._add_record_cname(key, hostname, rds = True)
 
-    def add_dynamo_table_from_json(self, key, name, KeySchema, AttributeDefinitions, ProvisionedThroughput, GlobalSecondaryIndexes=None):
+    def add_dynamo_table_from_json(self, key, name, KeySchema, AttributeDefinitions, ProvisionedThroughput, GlobalSecondaryIndexes=None, TimeToLiveSpecification=None):
         """Add DynamoDB table to the configuration using DynamoDB's calling convention.
 
         Example:
@@ -972,6 +972,7 @@ class CloudFormationConfiguration:
             AttributeDefinitions (list) : List of dict of AttributeName / AttributeType
             ProvisionedThroughput (dictionary) : Dictionary of ReadCapacityUnits / WriteCapacityUnits
             GlobalSecondaryIndexes (optional[list]): List of dicts representing global secondary indexes.  Defaults to None.
+            TimeToLiveSpecification (opitonal[dict]): Defines TTL attribute and whether it's enabled.
         """
 
         self.resources[key] = {
@@ -986,6 +987,9 @@ class CloudFormationConfiguration:
 
         if GlobalSecondaryIndexes is not None:
             self.resources[key]["Properties"]["GlobalSecondaryIndexes"] = GlobalSecondaryIndexes
+
+        if TimeToLiveSpecification is not None:
+            self.resources[key]["Properties"]["TimeToLiveSpecification"] = TimeToLiveSpecification
 
     def add_dynamo_table(self, key, name, attributes, key_schema, throughput):
         """Add an DynamoDB Table to the configuration

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -65,6 +65,9 @@ SALT_DIR = repo_path('salt_stack', 'salt')
 DYNAMO_METADATA_SCHEMA = SALT_DIR + '/boss/files/boss.git/django/bosscore/dynamo_schema.json'
 DYNAMO_S3_INDEX_SCHEMA = SALT_DIR + '/spdb/files/spdb.git/spatialdb/dynamo/s3_index_table.json'
 DYNAMO_TILE_INDEX_SCHEMA  = SALT_DIR + '/ndingest/files/ndingest.git/nddynamo/schemas/boss_tile_index.json'
+# Max number to append to task id attribute of tile index (used to prevent hot
+# partitions when writing to the task_id_index GSI).
+MAX_TASK_ID_SUFFIX = 100
 # Annotation id to supercuboid table.
 DYNAMO_ID_INDEX_SCHEMA = SALT_DIR + '/spdb/files/spdb.git/spatialdb/dynamo/id_index_schema.json'
 # Annotation id count table (allows for reserving the next id in a channel).


### PR DESCRIPTION
Set time-to-live (TTL) policies for the S3 tile bucket and DynamoDB tile index.

Objects or entries will be deleted after 21 days as a fallback for a failure during ingest cleanup.

Linked PR: https://github.com/jhuapl-boss/ndingest/pull/1