### PR TITLE
Use new GSI for tile index.

### DIFF
--- a/bin/update_lambda_fcn.py
+++ b/bin/update_lambda_fcn.py
@@ -177,6 +177,7 @@ def create_ndingest_settings(domain, fp):
     parser['aws']['cuboid_bucket'] = names.cuboid_bucket
     parser['aws']['tile_index_table'] = names.tile_index
     parser['aws']['cuboid_index_table'] = names.s3_index
+    parser['aws']['max_task_id_suffix'] = str(const.MAX_TASK_ID_SUFFIX)
 
     # parser['spdb']['SUPER_CUBOID_SIZE'] = CUBOIDSIZE[0]
     # ToDo: find way to always get cuboid size from spdb.

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -65,6 +65,9 @@ SALT_DIR = repo_path('salt_stack', 'salt')
 DYNAMO_METADATA_SCHEMA = SALT_DIR + '/boss/files/boss.git/django/bosscore/dynamo_schema.json'
 DYNAMO_S3_INDEX_SCHEMA = SALT_DIR + '/spdb/files/spdb.git/spatialdb/dynamo/s3_index_table.json'
 DYNAMO_TILE_INDEX_SCHEMA  = SALT_DIR + '/ndingest/files/ndingest.git/nddynamo/schemas/boss_tile_index.json'
+# Max number to append to task id attribute of tile index (used to prevent hot
+# partitions when writing to the task_id_index GSI).
+MAX_TASK_ID_SUFFIX = 100
 # Annotation id to supercuboid table.
 DYNAMO_ID_INDEX_SCHEMA = SALT_DIR + '/spdb/files/spdb.git/spatialdb/dynamo/id_index_schema.json'
 # Annotation id count table (allows for reserving the next id in a channel).


### PR DESCRIPTION
New GSI appends random number to job id so that writes are spread across multiple partitions.

Related ndingest PR: https://github.com/jhuapl-boss/ndingest/pull/2