### PR TITLE
bossSwitch script - to integration

### DIFF
--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -45,7 +45,9 @@ def main():
 
 #Executed actions
 def startInstances():
-
+    """
+        Method used to start necessary instances
+    """
     #Use auto scaling groups last saved configuration
     ASGdescription = load_obj('ASGdescriptions')
     activitiesD = [ASGdescription["AutoScalingGroups"][0]["MinSize"], ASGdescription["AutoScalingGroups"][0]["MaxSize"],ASGdescription["AutoScalingGroups"][0]["DesiredCapacity"]]
@@ -77,7 +79,9 @@ def startInstances():
 
 
 def stopInstances():
-
+    """
+        Method used to stop currently running instances
+    """
     #Save current ASG descriptions:
     print("Saving current auto scaling group configuration...")
     response = client.describe_auto_scaling_groups(AutoScalingGroupNames=[endpoint,activities,vaultg])
@@ -102,14 +106,33 @@ def stopInstances():
     print(bcolors.FAIL + "TheBoss is off" + bcolors.ENDC)
 
 def save_obj(obj, name ):
+    """
+        Method to save objects as .pkl files
+
+        Args:
+            obj : The object that will be saved
+            name : The .pkl file name under which the object will be saved
+    """
     with open('../'+ name + '.pkl', 'wb') as f:
         pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
 
 def load_obj(name):
+    """
+        Method to load saved objects in .pkl file
+
+        Args:
+            name : The .pkl file name to open
+        
+        Returns:
+            object saved within .pkl file
+    """
     with open('../' + name + '.pkl', 'rb') as f:
         return pickle.load(f)
 
 class bcolors:
+    """
+        Used to add coloring to terminal print statements
+    """
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
     WARNING = '\033[93m'

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3.5
+
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to turn the boss on and off.
+   ASG are shut down. Only execute this code if you are certain the boss will not
+   be running for another hour."""
+
+import boto3
+import sys
+import json
+import argparse
+import os
+import subprocess
+import time
+
+import alter_path
+from lib import aws, utils, vault
+
+def main():
+
+    choice = utils.get_user_confirm("Are you sure you want to proceed switching the boss on/off?")
+    if choice:
+        if args.action == "on":
+            print("Turning the BossDB on...")
+            startInstances()
+
+        elif args.action == "off":
+            print("Turning the BossDB off...")
+            stopInstances()
+
+#Executed actions
+def startInstances():
+
+    #Start vault instance
+    print("Starting vault...")
+    client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
+    client.resume_processes(AutoScalingGroupName=vaultg,ScalingProcesses=['HealthCheck'])
+    time.sleep(120)
+    print("Vault instance running")
+
+    #Import vault content:
+    subprocess.call('./bastion.py ' + args.vpc + ' vault-unseal',shell=True)
+    print("Importing vault content")
+    subprocess.call('./bastion.py ' + args.vpc + ' vault-import < ../config/vault_export.json', shell=True)
+    print(bcolors.WARNING + "Successful import" + bcolors.ENDC)    
+
+    #Start endpoint and activities instances
+    print("Starting endpoint, and activities...")
+    client.update_auto_scaling_group(AutoScalingGroupName=endpoint, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
+    client.resume_processes(AutoScalingGroupName=endpoint,ScalingProcesses=['HealthCheck'])
+    
+    client.update_auto_scaling_group(AutoScalingGroupName=activities, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
+    client.resume_processes(AutoScalingGroupName=activities,ScalingProcesses=['HealthCheck'])
+
+    print(bcolors.OKGREEN + "TheBoss is on" + bcolors.ENDC)
+
+
+def stopInstances():
+
+    #Export vault content:
+    print("Exporting vault content...")
+    subprocess.call('./bastion.py ' + args.vpc + ' vault-export > ../config/vault_export.json', shell=True)
+    print(bcolors.WARNING + "Successful export" + bcolors.ENDC)
+
+    #Switch off:
+    print("Stopping all Instances...")
+    client.update_auto_scaling_group(AutoScalingGroupName=endpoint, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
+    client.suspend_processes(AutoScalingGroupName=endpoint,ScalingProcesses=['HealthCheck'])
+
+    client.update_auto_scaling_group(AutoScalingGroupName=activities, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
+    client.suspend_processes(AutoScalingGroupName=activities,ScalingProcesses=['HealthCheck'])
+
+    client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
+    client.suspend_processes(AutoScalingGroupName=vaultg,ScalingProcesses=['HealthCheck'])
+
+    print(bcolors.FAIL + "TheBoss is off" + bcolors.ENDC)
+
+
+class bcolors:
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+
+if __name__ == '__main__':
+
+    def create_help(header, options):
+        """Create formated help."""
+        return "\n" + header + "\n" + \
+               "\n".join(map(lambda x: "  " + x, options)) + "\n"
+
+    actions = ["on", "off"]
+    actions_help = create_help("action supports the following:", actions)
+
+    scenarios = ["development", "production"]
+    scenario_help = create_help("scenario supports the following:", scenarios)
+
+    parser = argparse.ArgumentParser(description = "Script to turn the boss on and off by stopping and restarting EC2 instances.",
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog=actions_help + scenario_help)
+    parser.add_argument("--aws-credentials", "-a",
+                        metavar = "<file>",
+                        default = "../config/aws-credentials",
+                        help = "File with credentials to use when connecting to AWS (default: AWS_CREDENTIALS)")
+    parser.add_argument("--scenario",
+                        metavar = "<scenario>",
+                        default = "development",
+                        choices = scenarios,
+                        help = "The deployment configuration to use when creating the stack (instance size, autoscale group size, etc) (default: development)")
+    parser.add_argument("action",
+                        choices = actions,
+                        metavar = "action",
+                        help = "Action to execute")
+    parser.add_argument("vpc",
+                    metavar = "vpc-machine-name",
+                    help = "The vault machine name. ex: vault.user.boss")
+    args = parser.parse_args()
+
+    #Loading AWS configuration files.
+    creds = json.load(open(args.aws_credentials))
+    aws_access_key_id = creds["aws_access_key"]
+    aws_secret_access_key = creds["aws_secret_key"]
+    region_name = 'us-east-1'
+
+    if creds is None:
+        print("Error: AWS credentials not provided and AWS_CREDENTIALS is not defined")
+
+    # specify AWS keys, sets up connection to the client.
+    auth = {"aws_access_key_id": aws_access_key_id, "aws_secret_access_key": aws_secret_access_key, "region_name": region_name}
+    client = boto3.client('autoscaling', **auth)
+
+    if args.scenario == 'development':
+        #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
+        asg = json.load(open('../config/asg-cfg-dev'))
+        activities = asg["activities"]
+        endpoint = asg["endpoint"]
+        auth = asg["auth"]
+        vaultg = asg["vault"]
+        consul = asg["consul"]
+
+    elif args.scenario == 'production':
+        #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
+        asg = json.load(open('../config/asg-cfg'))
+        activities = asg["activities"]
+        endpoint = asg["endpoint"]
+        auth = asg["auth"]
+        vaultg = asg["vault"]
+        consul = asg["consul"]
+
+    else:
+        raise NameError('The asg-cfg or asg-cfg-dev need to exist.')
+
+    main()

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -72,7 +72,7 @@ def startInstances():
         with vault_tunnel(args.ssh_key, bastion):
             private = aws.machine_lookup(session,args.vpc,public_ip=False)
             vaultB.vault_unseal(vault.Vault(args.vpc, private))
-            vaultB.vault_import(vault.Vault(args.vpc, private), real_path + '/config/vault_export.json')
+            vaultB.vault_import(vault.Vault(args.vpc, private), REAL_PATH + '/config/vault_export.json')
         utils.console.okgreen("Successful import")
     except Exception as e:
         utils.console.fail("Unsuccessful import")
@@ -114,7 +114,7 @@ def stopInstances():
     print("Exporting vault content...") 
     try:
         with vault_tunnel(args.ssh_key, bastion): 
-            vaultB.vault_export(vault.Vault(args.vpc, private), real_path+'/config/vault_export.json')
+            vaultB.vault_export(vault.Vault(args.vpc, private), REAL_PATH+'/config/vault_export.json')
         utils.console.okgreen("Successful vaul export")
     except Exception as e:
         utils.console.fail("Unsuccessful vault export")
@@ -142,7 +142,7 @@ def save_obj(obj, name ):
             obj : The object that will be saved
             name : The .pkl file name under which the object will be saved
     """
-    with open(real_path + '/' + name + '.pkl', 'wb') as f:
+    with open(REAL_PATH + '/' + name + '.pkl', 'wb') as f:
         pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
 
 def load_obj(name):
@@ -155,13 +155,13 @@ def load_obj(name):
         Returns:
             object saved within .pkl file
     """
-    with open(real_path + '/' + name + '.pkl', 'rb') as f:
+    with open(REAL_PATH + '/' + name + '.pkl', 'rb') as f:
         return pickle.load(f)
 
 if __name__ == '__main__':
 
     #Grab files path to use as reference.
-    real_path = constants.repo_path()
+    REAL_PATH = constants.repo_path()
 
     def create_help(header, options):
         """Create formated help."""
@@ -205,7 +205,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     #Loading AWS configuration files.
-    creds = json.load(open(str(real_path + '/config/' + args.aws_credentials)))
+    creds = json.load(open(str(REAL_PATH + '/config/' + args.aws_credentials)))
     aws_access_key_id = creds["aws_access_key"]
     aws_secret_access_key = creds["aws_secret_key"]
     region_name = constants.REGION
@@ -232,7 +232,7 @@ if __name__ == '__main__':
         private = aws.machine_lookup(session, args.vpc, public_ip=False)
 
     #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
-    asg = json.load(open(str(real_path + '/config/' + args.config)))
+    asg = json.load(open(str(REAL_PATH + '/config/' + args.config)))
     activities = asg["activities"]
     endpoint = asg["endpoint"]
     vaultg = asg["vault"]

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -115,6 +115,7 @@ def stopInstances():
     try:
         with vault_tunnel(args.ssh_key, bastion): 
             vaultB.vault_export(vault.Vault(args.vpc, private), REAL_PATH+'/config/vault_export.json')
+        utils.console.warning("Please protect the vault_pexport.json file as it contains personal passwords.")
         utils.console.okgreen("Successful vaul export")
     except Exception as e:
         utils.console.fail("Unsuccessful vault export")

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -171,21 +171,13 @@ if __name__ == '__main__':
     actions = ["on", "off"]
     actions_help = create_help("action supports the following:", actions)
 
-    scenarios = ["development", "production"]
-    scenario_help = create_help("scenario supports the following:", scenarios)
-
     parser = argparse.ArgumentParser(description = "Script to turn the boss on and off by stopping and restarting EC2 instances.",
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=actions_help + scenario_help)
+                                     epilog=actions_help)
     parser.add_argument("--aws-credentials", "-a",
                         metavar = "<file>",
                         default = "aws-credentials",
                         help = "File with credentials to use when connecting to AWS (default: AWS_CREDENTIALS)")
-    parser.add_argument("--scenario",
-                        metavar = "<scenario>",
-                        default = "development",
-                        choices = scenarios,
-                        help = "The deployment configuration to use when creating the stack (instance size, autoscale group size, etc) (default: development)")
     parser.add_argument("--config",
                         metavar = "<config>",
                         default ="asg-cfg-dev",

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Script to turn the boss on and off.
-   The script aims at switch the boss on and off once it has been configured a first time.
+   The script aims to switch the boss on and off once it has been configured a first time.
    The instances should first be stood up by building stacks through cloudformation.
    ASG are shut down. Only execute this code if you are certain the boss will not
    be running for another hour."""
@@ -194,9 +194,6 @@ if __name__ == '__main__':
                         action='store_true',
                         default=False,
                         help = "add this flag to type in a private IP address in internal command instead of a DNS name which is looked up")
-    parser.add_argument("--user", "-u",
-                        default='ubuntu',
-                        help = "Username of the internal machine")
     parser.add_argument("--port",
                         default=22,
                         type=int,
@@ -241,8 +238,6 @@ if __name__ == '__main__':
         private = args.vpc
     else:
         private = aws.machine_lookup(session, args.vpc, public_ip=False)
-
-    ssh = SSHConnection(args.ssh_key, (private, args.port, args.user), bastion)
 
     #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
     asg = json.load(open(str(real_path + '/config/' + args.config)))

--- a/config/asg-cfg.example
+++ b/config/asg-cfg.example
@@ -1,0 +1,7 @@
+{
+    "activities": "ActivitiesBoss-Activities-ABC123",
+    "endpoint": "ApiBoss-Endpoint-ABC123",
+    "auth": "CoreBoss-Auth-ABC123",
+    "vault": "CoreBoss-Vault-ABC123",
+    "consul": "CoreBoss-Consul-ABC123"
+}

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -181,3 +181,20 @@ def get_user_confirm(message):
         return False
     else:
         return True
+
+class console:
+    """
+        Used to add coloring to terminal print statements
+    """
+
+    def warning(message):
+        print('\033[93m' + message +'\033[0m')
+
+    def okgreen(message):
+        print('\033[92m' + message +'\033[0m')
+
+    def okblue(message):
+        print('\033[94m' + message +'\033[0m')
+
+    def fail(message):
+        print('\033[91m' + message +'\033[0m')

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -187,14 +187,18 @@ class console:
         Used to add coloring to terminal print statements
     """
 
+    @staticmethod
     def warning(message):
         print('\033[93m' + message +'\033[0m')
 
+    @staticmethod
     def okgreen(message):
         print('\033[92m' + message +'\033[0m')
 
+    @staticmethod
     def okblue(message):
         print('\033[94m' + message +'\033[0m')
 
+    @staticmethod
     def fail(message):
         print('\033[91m' + message +'\033[0m')


### PR DESCRIPTION
Script to turn the boss on/off. The script stops endpoint, vault and activities instances by changing the settings of the related auto scaling groups. Stops the largest instances to reduce aws cost when the boss is not being used. 

**Features**
- Each auto scaling group's setting is saved locally as a pickle file and used when turning the boss back on to restore MinSize, MaxSize and DesiredCapacity back to the original figures.
- Before stopping the vault instance, its content is exported during boss shut down, saved locally and then imported when turned on. 
- Can be used for development and production scenarios (defaults dev)

**Use Requirements**
- asg-cfg or asg-cfg-dev file where auto scaling group names are saved. 

_Tested on Dev stacks_