### PR TITLE
Redis session

### DIFF
--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -75,10 +75,17 @@ def create_config(session, domain, keypair=None, db_config={}):
     user_data["aws"]["db"] = names.endpoint_db
     user_data["aws"]["cache"] = names.cache
     user_data["aws"]["cache-state"] = names.cache_state
+    if get_scenario(const.REDIS_SESSION_TYPE, None) is not None:
+        user_data["aws"]["cache-session"] = names.cache_session
+    else:
+        # Don't create a Redis server for dev stacks.
+        user_data["aws"]["cache-session"] = ''
+
 
     ## cache-db and cache-stat-db need to be in user_data for lambda to access them.
     user_data["aws"]["cache-db"] = "0"
     user_data["aws"]["cache-state-db"] = "0"
+    user_data["aws"]["cache-session-db"] = "0"
     user_data["aws"]["meta-db"] = names.meta
 
     # Use CloudFormation's Ref function so that queues' URLs are placed into

--- a/cloud_formation/configs/redis.py
+++ b/cloud_formation/configs/redis.py
@@ -75,6 +75,16 @@ def create_config(session, domain, keypair=None):
                                  version="3.2.4",
                                  clusters=const.REDIS_CLUSTER_SIZE)
 
+    # This one may not be created depending on the scenario type.
+    if get_scenario(const.REDIS_SESSION_TYPE, None) is not None:
+        config.add_redis_replication("CacheSession",
+                                     names.cache_session,
+                                     az_subnets,
+                                     [sgs[names.internal]],
+                                     type_=const.REDIS_SESSION_TYPE,
+                                     version="3.2.4",
+                                     clusters=const.REDIS_CLUSTER_SIZE)
+
     return config
 
 

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -118,6 +118,13 @@ REDIS_CACHE_TYPE = {
     "ha-development": "cache.t2.small",
 }
 
+# Django session cache using Redis.
+REDIS_SESSION_TYPE = {
+    "development": None,            # Don't use Redis for dev stack sessions.
+    "production": "cache.t2.small",
+    "ha-development": "cache.t2.small",
+}
+
 REDIS_TYPE = {
     "development": "cache.t2.small",
     "production": "cache.m4.xlarge",

--- a/lib/names.py
+++ b/lib/names.py
@@ -78,7 +78,8 @@ class AWSNames(object):
         "http": "http",
         "internet": "internet",
         "meta": "bossmeta",
-        "cache": "cache",
+        'cache_session': 'cache-session',   # Redis server for Django sessions.
+        "cache": "cache",                   # Redis server to cache cuboids.
         "cache_state": "cache-state",
         "cache_manager": "cachemanager",
         "cache_db": "cachedb",


### PR DESCRIPTION
Create a Redis server for caching Django sessions when not building a dev stack

Adds new boss.config variables:
cache-session (name of Redis server)
cache-session-db (Redis DB #, should always be 0 unless writing to a test DB)

Related PR:
https://github.com/jhuapl-boss/boss/pull/16