### PR TITLE
Extract tile upload and ingest lambdas

### DIFF
--- a/bin/update_lambda_fcn.py
+++ b/bin/update_lambda_fcn.py
@@ -84,7 +84,9 @@ def update_lambda_code(session, domain, bucket):
         names.delete_tile_index_entry_lambda,
         names.cuboid_import_lambda,
         names.copy_cuboid_lambda,
-        names.volumetric_ingest_queue_upload_lambda
+        names.volumetric_ingest_queue_upload_lambda,
+        names.tile_uploaded_lambda,
+        names.tile_ingest_lambda
     ]
     client = session.client('lambda')
     for lambda_name in uses_multilambda:

--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -105,7 +105,7 @@ def create_config(session, domain, keypair=None, db_config={}):
     user_data["auth"]["OIDC_VERIFY_SSL"] = 'True'
     user_data["lambda"]["flush_function"] = names.multi_lambda
     user_data["lambda"]["page_in_function"] = names.multi_lambda
-    user_data["lambda"]["ingest_function"] = names.multi_lambda
+    user_data["lambda"]["ingest_function"] = names.tile_ingest_lambda
     user_data["lambda"]["downsample_volume"] = names.downsample_volume_lambda
 
     user_data['sfn']['populate_upload_queue'] = names.ingest_queue_populate

--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -40,7 +40,7 @@ import botocore
 EXPIRE_IN_DAYS = 21
 
 # Ids used for bucket lambda triggers.
-TILE_BUCKET_TRIGGER = 'tileBucketInvokeMultiLambda'
+TILE_BUCKET_TRIGGER = 'tileBucketInvokeTileUploadedLambda'
 INGEST_BUCKET_TRIGGER = 'ingestBucketInvokeCuboidImportLambda'
 
 CUBOID_IMPORT_ROLE = 'CuboidImportLambdaRole'
@@ -248,8 +248,8 @@ def create_config(session, domain, keypair=None, user_data=None):
                       s3=(lambda_bucket,
                           "multilambda.{}.zip".format(domain),
                           "tile_uploaded_lambda.handler"),
-                      timeout=120,
-                      memory=1024,
+                      timeout=30,
+                      memory=256,
                       runtime='python3.6')
     config.add_lambda("TileIngestLambda",
                       names.tile_ingest_lambda,
@@ -310,10 +310,10 @@ def create_config(session, domain, keypair=None, user_data=None):
         )
     else:
         config.add_lambda_permission(
-            'tileBucketInvokeMultiLambda', names.multi_lambda,
+            'tileBucketInvokeMultiLambda', names.tile_uploaded_lambda,
             principal='s3.amazonaws.com', source={
                 'Fn::Join': [':', ['arn', 'aws', 's3', '', '', tile_bucket_name]]},
-            depends_on='MultiLambda'
+            depends_on='TileUploadedLambda'
         )
 
     if creating_ingest_bucket:

--- a/lib/names.py
+++ b/lib/names.py
@@ -145,7 +145,7 @@ class AWSNames(object):
                     'delete_tile_objs_lambda', 'delete_tile_index_entry_lambda',
                     'copy_cuboid_lambda', 'cuboid_import_lambda',
                     'volumetric_ingest_queue_upload_lambda', 'tile_ingest_lambda',
-                    'tile_upload_lambda'
+                    'tile_uploaded_lambda'
                     ]:
             fq_hostname = fq_hostname.replace('.','-')
 

--- a/lib/names.py
+++ b/lib/names.py
@@ -125,7 +125,9 @@ class AWSNames(object):
         'cuboid_import_lambda': 'cuboidImportLambda',
         'cuboid_import_dlq': 'cuboidImportDlq',
         'copy_cuboid_lambda': 'copyCuboidLambda',
-        'copy_cuboid_dlq': 'copyCuboidDlq'
+        'copy_cuboid_dlq': 'copyCuboidDlq',
+        'tile_uploaded_lambda': 'tileUploadLambda',
+        'tile_ingest_lambda': 'tileIngestLambda'
     }
 
     def __getattr__(self, name):
@@ -142,7 +144,8 @@ class AWSNames(object):
                     'delete_lambda', 'ingest_lambda', 'dynamo_lambda', 'downsample_dlq', 'downsample_volume_lambda',
                     'delete_tile_objs_lambda', 'delete_tile_index_entry_lambda',
                     'copy_cuboid_lambda', 'cuboid_import_lambda',
-                    'volumetric_ingest_queue_upload_lambda'
+                    'volumetric_ingest_queue_upload_lambda', 'tile_ingest_lambda',
+                    'tile_upload_lambda'
                     ]:
             fq_hostname = fq_hostname.replace('.','-')
 


### PR DESCRIPTION
Split out tile_upload and ingest lambdas.

Removed these lambdas from the multilambda.

Renamed to tile_uploaded_lambda and tile_ingest_lambda to indicate that these lambdas are only involved in tile based ingests.

Branched this from the volumetric ingest branch since we're not moving to get this in immediately.

Related PR:
https://github.com/jhuapl-boss/boss-tools/pull/21