### PR TITLE
Run post_init() automatically during update.

### DIFF
--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -375,6 +375,8 @@ def update(session, domain):
         bucket = aws.get_lambda_s3_bucket(session)
         update_lambda_code(session, domain, bucket)
 
+    post_init()
+
     return success
 
 


### PR DESCRIPTION
For cachedb, automatically run post_init() as the last step of an
update, so the user doesn't need to remember.  post_init() adds bucket
triggers and life cycle policies.