### PR TITLE
Update boss-tools submodule.

### DIFF
--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -375,7 +375,7 @@ def update(session, domain):
         bucket = aws.get_lambda_s3_bucket(session)
         update_lambda_code(session, domain, bucket)
 
-    post_init()
+    post_init(session, domain)
 
     return success
 


### PR DESCRIPTION
Fixed call to post_init() w/o params in cachedb.py.