### PR TITLE
Added ability for Auth to have different Instance types

### DIFF
--- a/cloud_formation/configs/core.py
+++ b/cloud_formation/configs/core.py
@@ -40,13 +40,14 @@ from concurrent.futures import ThreadPoolExecutor
 
 keypair = None
 
-def create_asg_elb(config, key, hostname, ami, keypair, user_data, size, isubnets, esubnets, listeners, check, sgs=[], role = None, public=True, depends_on=None):
+def create_asg_elb(config, key, hostname, ami, keypair, user_data, size, isubnets, esubnets, listeners, check, sgs=[], role = None, type_="t2.micro", public=True, depends_on=None):
     security_groups = [Ref("InternalSecurityGroup")]
     config.add_autoscale_group(key,
                                hostname,
                                ami,
                                keypair,
                                subnets = isubnets,
+                               type_= type_,
                                security_groups = security_groups,
                                user_data = user_data,
                                min = size,
@@ -160,6 +161,7 @@ def create_config(session, domain):
                    [("443", "8080", "HTTPS", cert)],
                    "HTTP:8080/index.html",
                    sgs = [Ref("AuthSecurityGroup")],
+                   type_=const.AUTH_TYPE,
                    depends_on=deps)
 
     if USE_DB:

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -127,7 +127,7 @@ REDIS_SESSION_TYPE = {
 
 REDIS_TYPE = {
     "development": "cache.t2.small",
-    "production": "cache.m4.xlarge",
+    "production": "cache.m5.xlarge",
     "ha-development": "cache.t2.small",
 }
 
@@ -143,6 +143,11 @@ ACTIVITIES_TYPE = {
     "ha-development": "m5.large",
 }
 
+AUTH_TYPE = {
+    "development": "t2.micro",
+    "production": "m5.xlarge",
+    "ha-development": "t2.micro",
+}
 
 ########################
 # Machine Cluster Sizes


### PR DESCRIPTION
Added ability for Auth to have different instance types.
Changed default type size for redis_type from cache.m4.xlarge to cache.m5.xlarge as it is the same price and 5 has better performance.