### PR TITLE
fixed a missing comma list separator

### DIFF
--- a/bin/update_lambda_fcn.py
+++ b/bin/update_lambda_fcn.py
@@ -94,7 +94,7 @@ def update_lambda_code(session, domain, bucket):
         names.index_write_failed_lambda, names.index_find_cuboids_lambda,
         names.copy_cuboid_lambda,
         names.tile_uploaded_lambda,
-        names.tile_ingest_lambda
+        names.tile_ingest_lambda,
         names.index_fanout_enqueue_cuboid_keys_lambda,
         names.index_batch_enqueue_cuboids_lambda,
         names.index_fanout_dequeue_cuboid_keys_lambda,


### PR DESCRIPTION
Found and fixed a missing comma (list items separator), per the slack channel discussion details.