### PR TITLE
Added increase size in filehandles to the endpoint sls file.

### DIFF
--- a/salt_stack/salt/top.sls
+++ b/salt_stack/salt/top.sls
@@ -27,6 +27,7 @@ base:
         - git
         - ingest-client.ingest
         - chrony
+        - open-files.increase-open-files
 
     'lambda*':
         - lambda-dev


### PR DESCRIPTION
I noticed when updating production recently that the files handlers were only 4096.  I added the already creates sls file for increase filehandle counts to the endpoint.