### PR TITLE
Successful update to nodejs8.10 runtime - to integration

### DIFF
--- a/cloud_formation/configs/dynamolambda.py
+++ b/cloud_formation/configs/dynamolambda.py
@@ -96,7 +96,7 @@ def create_config(session, domain):
                           "index.handler"),
                       timeout=120,
                       memory=128,
-                      runtime="nodejs6.10",
+                      runtime="nodejs8.10",
                       reserved_executions=1)
 
     config.add_cloudwatch_rule(TRIGGER_KEY,


### PR DESCRIPTION
Updated lambda runtime from nodeJS 6.10 to 8.10. After receiving notification from AWS, that nodeJS6.10 was approaching EOL and AWS's lambda's would no longer be able to use nodeJS6.10 we decided to update our dynamo lambda's runtime to use a more recent one. 

8.10 is backwards compatible. 

Lambda executes without failures. 
