### PR TITLE
Cuboid importlambda role update - to master

### DIFF
--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -191,6 +191,7 @@ def create_config(session, domain, keypair=None, user_data=None):
  
     # Allow updating S3 index table with cuboid's object key during
     # volumetric ingest.
+    # Example of s3_index_arn form: arn:aws:dynamodb:us-east-1:256215146792:table/s3index.*.boss
     config.add_iam_policy_to_role(
         'S3IndexPutItem{}'.format(domain).replace('.', ''),
         get_s3_index_arn(session, domain).replace(domain,'*.') + domain.split('.')[1],

--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -191,7 +191,7 @@ def create_config(session, domain, keypair=None, user_data=None):
  
     # Allow updating S3 index table with cuboid's object key during
     # volumetric ingest.
-    # Example of s3_index_arn form: arn:aws:dynamodb:us-east-1:256215146792:table/s3index.*.boss
+    # Example of s3_index_arn form: arn:aws:dynamodb:us-east-1:12345678:table/s3index.*.boss
     config.add_iam_policy_to_role(
         'S3IndexPutItem{}'.format(domain).replace('.', ''),
         get_s3_index_arn(session, domain).replace(domain,'*.') + domain.split('.')[1],

--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -193,7 +193,7 @@ def create_config(session, domain, keypair=None, user_data=None):
     # volumetric ingest.
     config.add_iam_policy_to_role(
         'S3IndexPutItem{}'.format(domain).replace('.', ''),
-        get_s3_index_arn(session, domain),
+        get_s3_index_arn(session, domain).replace(domain,'*.') + domain.split('.')[1],
         [CUBOID_IMPORT_ROLE], ['dynamodb:PutItem'])
 
     cuboid_bucket_name = names.cuboid_bucket

--- a/config/iam/roles.json
+++ b/config/iam/roles.json
@@ -389,7 +389,7 @@
                 "dynamodb:PutItem"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:dynamodb:us-east-1:451493790433:table/s3index.integration.boss"
+              "Resource": "arn:aws:dynamodb:us-east-1:451493790433:table/s3index.*.boss"
             }
           ],
           "Version": "2012-10-17"

--- a/lib/hosts.py
+++ b/lib/hosts.py
@@ -97,6 +97,7 @@ VPCS = {
     "leea1"    : 106,
     "manavpj1" : 107,
     "davismj1" : 108,
+    "rodrilm2" : 109,
 
 }
 


### PR DESCRIPTION
Fixes - cuboidImportlambda role overwrites pervious permissions to dynamoDB table

NOTE: This code change is still awaiting a volumetric ingest test, to make sure the role is used correctly