### PR TITLE
Use proper CloudFormation template syntax.

### DIFF
--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -65,17 +65,15 @@ def get_cf_bucket_life_cycle_rules():
             {
                 'ExpirationInDays': EXPIRE_IN_DAYS,
                 'Status': 'Enabled',
-                'Filter': {}
             },
             {
                 # Marked for deletion rule.
                 'ExpirationInDays': MARKED_FOR_DELETION_DAYS,
                 'Status': 'Enabled',
-                'Filter': {
-                    'Tag': {
-                        'Key': TAG_DELETE_KEY,
-                        'Value': TAG_DELETE_VALUE }
-                }
+                'TagFilters': [{
+                    'Key': TAG_DELETE_KEY,
+                    'Value': TAG_DELETE_VALUE
+                }]
             }
         ]
     }


### PR DESCRIPTION
boto3 uses a different way of specifying filters for S3 bucket life cycle policies. This code path had never been run before and revealed errors with the CloudFormation version of setting life cycle policies.