### PR TITLE
Run lambda using Python 3.6.

### DIFF
--- a/cloud_formation/configs/activities.py
+++ b/cloud_formation/configs/activities.py
@@ -107,6 +107,7 @@ def create_config(session, domain):
                       const.INGEST_LAMBDA,
                       handler="index.handler",
                       timeout=60 * 5,
+                      runtime='python3.6',
                       memory=3008)
 
     config.add_lambda_permission("IngestLambdaExecute", Ref("IngestLambda"))


### PR DESCRIPTION
No longer a need to run under 2.7.  Also, under 2.7, math.ceil() returns
a float instead of an int.  This was causing problems at runtime.  No
need to make sure to cast to int under 3.6.