### PR TITLE
Exclude Scalyr if pillar file not found.

### DIFF
--- a/docs/InitialBossSetup.md
+++ b/docs/InitialBossSetup.md
@@ -35,12 +35,4 @@ Then paste in the Log Access Key for Writes into your account.
 You'll need to do this before building AMIs with packer 
 
 ### Not Using Scalyr
-If you do not want to use Scaylr do the following
-Zero out the contents of the files but leave the files there.
-
-boss-manage/salt_stack/salt/scalyr/init.sls
-boss-manage/salt_stack/salt/scalyr/map.jinja
-boss-manage/salt_stack/salt/scalyr/update_host.sls
-
-Currently, errors will occur if the files are not there.
-
+If you do not want to use Scaylr, there is nothing you need to do.

--- a/salt_stack/pillar/top.sls
+++ b/salt_stack/pillar/top.sls
@@ -1,6 +1,19 @@
+# Check for existence of scalyr.sls at the root of a pillar folder.
+{% set roots = salt['config.get']('pillar_roots:base') %}
+{% set scalyr = {'exists': false} %}
+{% for path in roots if salt['file.file_exists'](path + '/scalyr.sls') %}
+  {% if scalyr.update({'exists': true}) %}
+    # Hack to update a variable inside a loop (not supported by Jinja version
+    # used by our version of Salt).  We can update the value of a dict, though.
+  {% endif %}
+  {% break %}
+{% endfor %}
+
 base:
+{% if scalyr.exists  %}
   '*':
     - scalyr
+{% endif %}
 
   'endpoint*':
     - endpoint

--- a/salt_stack/salt/scalyr/init.sls
+++ b/salt_stack/salt/scalyr/init.sls
@@ -1,38 +1,41 @@
 {% from "scalyr/map.jinja" import scalyr with context %}
+{% set use_scalyr = salt['pillar.get']('scalyr:log_key', False) != False %}
 
-# Install the Scalyr Agent for log aggregation.
-scalyr_pkg:
-    # Manually add Scalyr to package repo.
-    cmd.run:
-        - name: |
-            VERSION="1.2.1"
-            wget -q https://www.scalyr.com/scalyr-repo/stable/latest/scalyr-repo-bootstrap_${VERSION}_all.deb
-            sudo dpkg -r scalyr-repo scalyr-repo-bootstrap # Remove old repo defs.
-            sudo dpkg -i scalyr-repo-bootstrap_${VERSION}_all.deb
-            sudo apt-get update
-            rm /tmp/scalyr-repo-bootstrap_${VERSION}_all.deb
-        - cwd: /tmp
-        - shell: /bin/bash
-        - unless: test -x /usr/sbin/scalyr-agent-2
+{% if use_scalyr %}
+    # Install the Scalyr Agent for log aggregation.
+    scalyr_pkg:
+        # Manually add Scalyr to package repo.
+        cmd.run:
+            - name: |
+                VERSION="1.2.1"
+                wget -q https://www.scalyr.com/scalyr-repo/stable/latest/scalyr-repo-bootstrap_${VERSION}_all.deb
+                sudo dpkg -r scalyr-repo scalyr-repo-bootstrap # Remove old repo defs.
+                sudo dpkg -i scalyr-repo-bootstrap_${VERSION}_all.deb
+                sudo apt-get update
+                rm /tmp/scalyr-repo-bootstrap_${VERSION}_all.deb
+            - cwd: /tmp
+            - shell: /bin/bash
+            - unless: test -x /usr/sbin/scalyr-agent-2
 
-scalyr:
-    pkg.installed:
-        - pkgs:
-            - scalyr-repo
-            - scalyr-agent-2
+    scalyr:
+        pkg.installed:
+            - pkgs:
+                - scalyr-repo
+                - scalyr-agent-2
 
-set_scalyr_log_key:
-    cmd.run:
-        - name: scalyr-agent-2-config --set-key "{{ salt['pillar.get']('scalyr:log_key', '') }}"
+    set_scalyr_log_key:
+        cmd.run:
+            - name: scalyr-agent-2-config --set-key "{{ salt['pillar.get']('scalyr:log_key', '') }}"
 
-scalyr_running:
-    service.running:
-        - name: scalyr-agent-2
+    scalyr_running:
+        service.running:
+            - name: scalyr-agent-2
 
-{% for logs, path in scalyr.log_config_files.iteritems() %}
-scalyr_copy_log_config_{{ logs }}:
-    file.managed:
-        - name: /etc/scalyr-agent-2/agent.d/{{ logs }}.json
-        - source:
-            - {{ path }}
-{% endfor %}
+    {% for logs, path in scalyr.log_config_files.iteritems() %}
+    scalyr_copy_log_config_{{ logs }}:
+        file.managed:
+            - name: /etc/scalyr-agent-2/agent.d/{{ logs }}.json
+            - source:
+                - {{ path }}
+    {% endfor %}
+{% endif %}

--- a/salt_stack/salt/scalyr/update_host.sls
+++ b/salt_stack/salt/scalyr/update_host.sls
@@ -1,13 +1,18 @@
 # Update the host name in /etc/scalyr-agent-2/agent.json during first
 # boot.
 
-scalyr_set_host_name:
-    file.managed:
-        - name: /etc/init.d/scalyr-firstboot
-        - source: salt://scalyr/files/firstboot.py
-        - user: root
-        - group: root
-        - mode: 555
-    cmd.run:
-        - name: update-rc.d scalyr-firstboot start 95 2 3 4 5 .
-        - user: root
+{% set use_scalyr = salt['pillar.get']('scalyr:log_key', False) != False %}
+{% if use_scalyr %}
+
+    scalyr_set_host_name:
+        file.managed:
+            - name: /etc/init.d/scalyr-firstboot
+            - source: salt://scalyr/files/firstboot.py
+            - user: root
+            - group: root
+            - mode: 555
+        cmd.run:
+            - name: update-rc.d scalyr-firstboot start 95 2 3 4 5 .
+            - user: root
+
+{% endif %}

--- a/salt_stack/salt/top.sls
+++ b/salt_stack/salt/top.sls
@@ -1,5 +1,8 @@
-{% set use_scalyr = salt['pillar.get']('scalyr:log_key', False) != False %}
-        
+#
+# Note Scalyr formulas are only applied if 'scalyr:log_key' set in
+# pillars.
+
+
 base:
     'consul*':
         - consul
@@ -9,10 +12,8 @@ base:
     'vault*':
         - vault.server
         - boss-tools.bossutils
-        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
-        {% endif %}
         - chrony
 
     'auth*':
@@ -26,10 +27,8 @@ base:
         - django.rest-framework # install first and patch
         - boss.django
         - django.login # patch, expects django to already be installed
-        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
-        {% endif %}
         - git
         - ingest-client.ingest
         - chrony
@@ -52,10 +51,8 @@ base:
         - django.rest-framework # install first and patch
         - proofreader-web
         - django.login # patch, expects django to already be installed
-        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
-        {% endif %}
 
     'workstation*':
         - python.python35
@@ -67,18 +64,14 @@ base:
     'cachemanager*':
         - boss-tools.bossutils
         - boss-tools.cachemanager
-        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
-        {% endif %}
         - git
         - chrony
 
     'activities*':
-        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
-        {% endif %}
         - open-files.increase-open-files
         - boss-tools.activities
 

--- a/salt_stack/salt/top.sls
+++ b/salt_stack/salt/top.sls
@@ -1,3 +1,5 @@
+{% set use_scalyr = salt['pillar.get']('scalyr:log_key', False) != False %}
+        
 base:
     'consul*':
         - consul
@@ -7,8 +9,10 @@ base:
     'vault*':
         - vault.server
         - boss-tools.bossutils
+        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
+        {% endif %}
         - chrony
 
     'auth*':
@@ -22,8 +26,10 @@ base:
         - django.rest-framework # install first and patch
         - boss.django
         - django.login # patch, expects django to already be installed
+        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
+        {% endif %}
         - git
         - ingest-client.ingest
         - chrony
@@ -46,8 +52,10 @@ base:
         - django.rest-framework # install first and patch
         - proofreader-web
         - django.login # patch, expects django to already be installed
+        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
+        {% endif %}
 
     'workstation*':
         - python.python35
@@ -59,14 +67,18 @@ base:
     'cachemanager*':
         - boss-tools.bossutils
         - boss-tools.cachemanager
+        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
+        {% endif %}
         - git
         - chrony
 
     'activities*':
+        {% if use_scalyr %}
         - scalyr
         - scalyr.update_host
+        {% endif %}
         - open-files.increase-open-files
         - boss-tools.activities
 


### PR DESCRIPTION
Only include Scalyr formulas when building AMIs if there is a scalyr.sls
file found in the root of a pillar.

Use some nasty Jinja template hackery to check for existence of a scalyr.sls file. There can be more than one pillar root defined, so I iterate through the list in case we ever define more in the future.