### PR TITLE
DynamoDB autoscale lambda refactor

### DIFF
--- a/cloud_formation/dynamodb-autoscale/BossDefaultProvisioners.json
+++ b/cloud_formation/dynamodb-autoscale/BossDefaultProvisioners.json
@@ -1,0 +1,62 @@
+{
+    "default": {
+        "ReadCapacity": {
+          "Min": 1,
+          "Max": 100,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 2
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 1,
+          "Max": 100,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 2
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    }
+}

--- a/cloud_formation/dynamodb-autoscale/BossProductionProvisioners.json
+++ b/cloud_formation/dynamodb-autoscale/BossProductionProvisioners.json
@@ -1,0 +1,362 @@
+{
+    "default": {
+        "ReadCapacity": {
+          "Min": 1,
+          "Max": 100,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 2
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 1,
+          "Max": 100,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 2
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "bossmeta_cfg": {
+        "ReadCapacity": {
+          "Min": 5,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 5,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "idCount_cfg": {
+        "ReadCapacity": {
+          "Min": 5,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 10,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "idIndex_cfg": {
+        "ReadCapacity": {
+          "Min": 25,
+          "Max": 35000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 50,
+          "Max": 35000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 50,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 200
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "s3index_cfg": {
+        "ReadCapacity": {
+          "Min": 25,
+          "Max": 40000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 25,
+          "Max": 40000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "tileindex_cfg": {
+        "ReadCapacity": {
+          "Min": 5,
+          "Max": 40000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 5,
+          "Max": 40000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    }
+}

--- a/cloud_formation/dynamodb-autoscale/BossTableConfig.json
+++ b/cloud_formation/dynamodb-autoscale/BossTableConfig.json
@@ -1,0 +1,7 @@
+{
+    "bossmeta": "bossmeta_cfg",
+    "idCount": "idCount_cfg",
+    "idIndex": "idIndex_cfg",
+    "s3index": "s3index_cfg",
+    "tileindex": "tileindex_cfg"
+}

--- a/config/boss_config.py.example
+++ b/config/boss_config.py.example
@@ -70,6 +70,14 @@ BILLING_CURRENCY : str = "USD" # (Optional) Currency that the threasholds are se
 ALERT_TOPIC : str = "BossMailingList" # (Optional) SNS topic for receiving alerts or error messages from a running Boss process
                                       #            Different Boss components are configured to send notifications to this topic
 
+SLACK_WEBHOOK_HOST : str = "hooks.slack.com" # (Optional) Hostname for Slack webhooks
+SLACK_WEBHOOK_PATH_DYNAMODB_AUTOSCALE : str = None # (Optional) Webhook path for submitting details about the DynamoDB autoscale lambda changes
+                                                   #            If not provided the autoscale lambda will not use Slack for notifications
+
+DYNAMODB_AUTOSCALE_PROVISIONER : str = "BossDefaultProvisioners" # (Optional) The name of the JSON file in the cloud_formation/dynamodb-autoscale/ directory
+                                                                 #            The JSON file contains the autoscale rules used by the DynamoDB autoscale lambda
+
+
 ###
 # Minimal Config for Account Setup
 # When using the bin/boss-account.py and bin/iam_utils.py scripts to initially

--- a/lib/configuration.py
+++ b/lib/configuration.py
@@ -76,6 +76,9 @@ class BossConfiguration(object):
         'BILLING_THRESHOLDS', # Conditional, required if setting up account
         'BILLING_CURRENCY', # Optional
         'ALERT_TOPIC', # Optional
+        'SLACK_WEBHOOK_HOST', # Optional
+        'SLACK_WEBHOOK_PATH_DYNAMODB_AUTOSCALE', # Conditional, to use Slack integration
+        'DYNAMODB_AUTOSCALE_PROVISIONER', # Optional
     ]
 
     __DEFAULTS = {
@@ -90,6 +93,9 @@ class BossConfiguration(object):
         "BILLING_TOPIC": "BossBillingList",
         "BILLING_CURRENCY": "USD",
         "ALERT_TOPIC": "BossMailingList",
+        'SLACK_WEBHOOK_HOST': 'hooks.slack.com',
+        'SLACK_WEBHOOK_PATH_DYNAMODB_AUTOSCALE': None,
+        'DYNAMODB_AUTOSCALE_PROVISIONER': 'BossDefaultProvisioners',
     }
 
     def __init__(self, bosslet, **kwargs):


### PR DESCRIPTION
* Slack variables (in `dynamo_config.template`) are pushed into the bosslet config
* Slack variables are optional (submodule will be updated to make the Slack call optional)
* The Boss provisioner configuration files are moved into boss-manage
* The Boss provisioner configuration file is configurable via the bosslet config, allowing other autoscaling configurations (similar to how we allow multiple scenarios)

The jhuapl-boss/dynamodb-lambda-autoscale#3 PR has the lambda changes