### PR TITLE
 Switch from classic to application load balancer.

### DIFF
--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -31,7 +31,7 @@ MIGRATION CHANGELOG:
 DEPENDENCIES = ['core', 'redis'] # also depends on activities for step functions
                                  # but this forms a circular dependency
 
-from lib.cloudformation import CloudFormationConfiguration, Arg, Ref, Arn
+from lib.cloudformation import CloudFormationConfiguration, Arg, Ref, Arn, AppLoadBalancerListenerCfg
 from lib.userdata import UserData
 from lib.keycloak import KeyCloakClient
 from lib.exceptions import BossManageCanceled, MissingResourceError
@@ -160,17 +160,9 @@ def create_config(bosslet_config, db_config={}):
     # Create the endpoint ASG, ELB, and RDS instance
 
     cert = aws.cert_arn_lookup(session, names.public_dns("api"))
-    """
-    config.add_loadbalancer("EndpointLoadBalancer",
-                            names.endpoint_elb.dns,
-                            [("443", "80", "HTTPS", cert)],
-                            subnets=external_subnets_asg,
-                            security_groups=[sgs[names.internal.sg], sgs[names.https.sg]],
-                            public=True)
-    """
     target_group_keys = config.add_app_loadbalancer("EndpointAppLoadBalancer",
                             names.endpoint_elb.dns,
-                            [("443", "80", "HTTPS", cert)],
+                            [AppLoadBalancerListenerCfg("443", "80", "HTTPS", cert)],
                             vpc_id=vpc_id,
                             subnets=external_subnets_asg,
                             security_groups=[sgs[names.internal.sg], sgs[names.https.sg]],
@@ -179,6 +171,7 @@ def create_config(bosslet_config, db_config={}):
     target_group_arns = [Ref(key) for key in target_group_keys]
 
     config.add_public_dns('EndpointAppLoadBalancer', names.public_dns('api'))
+
     config.add_autoscale_group("Endpoint",
                                names.endpoint.dns,
                                aws.ami_lookup(bosslet_config, names.endpoint.ami),

--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -39,11 +39,9 @@ from lib import aws
 from lib import console
 from lib import utils
 from lib import constants as const
-from lib import console
 
 import json
 import uuid
-import sys
 from urllib.request import Request, urlopen
 from urllib.parse import urlencode
 
@@ -160,14 +158,6 @@ def create_config(bosslet_config, db_config={}):
     # Create the endpoint ASG, ELB, and RDS instance
 
     cert = aws.cert_arn_lookup(session, names.public_dns("api"))
-    """
-    config.add_loadbalancer("EndpointLoadBalancer",
-                            names.endpoint_elb.dns,
-                            [("443", "80", "HTTPS", cert)],
-                            subnets=external_subnets_asg,
-                            security_groups=[sgs[names.internal.sg], sgs[names.https.sg]],
-                            public=True)
-    """
     target_group_keys = config.add_app_loadbalancer("EndpointAppLoadBalancer",
                             names.endpoint_elb.dns,
                             [("443", "80", "HTTPS", cert)],
@@ -314,7 +304,6 @@ def create(bosslet_config):
     post_init(bosslet_config)
 
 def post_init(bosslet_config):
-    session = bosslet_config.session
     call = bosslet_config.call
     names = bosslet_config.names
 

--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -182,13 +182,11 @@ def create_config(bosslet_config, db_config={}):
                                user_data=parsed_user_data,
                                min=const.ENDPOINT_CLUSTER_MIN,
                                max=const.ENDPOINT_CLUSTER_MAX,
-                               #elb=Ref("EndpointLoadBalancer"),
                                notifications=dns_arn,
                                role=aws.instance_profile_arn_lookup(session, 'endpoint'),
                                health_check_grace_period=90,
                                detailed_monitoring=True,
                                target_group_arns=target_group_arns,
-                               #depends_on=["EndpointLoadBalancer", "EndpointDB"])
                                depends_on=["EndpointDB"])
 
     # Endpoint servers are not CPU bound typically, so react quickly to load

--- a/lib/cloudformation.py
+++ b/lib/cloudformation.py
@@ -1428,7 +1428,7 @@ class CloudFormationConfiguration:
             listeners (list) : A list of AppLoadBalancerListenerCfg for the elb
             vpc_id (None|str) : Required unless directing traffic to a lambda
             instances (None|list) : A list of Instance IDs or Refs to attach to the LoadBalancer
-            subnets (None|list) : A list of Subnet IDs or Refsto attach the LoadBalancer to
+            subnets (None|list) : A list of Subnet IDs or Refs to attach the LoadBalancer to
             security_groups (None|list) : A list of SecurityGroup IDs or Refs to apply to the LoadBalancer
             healthcheck_path (str) : The path used for for health checks Ex: "/alive/"
             public (bool) : If the ELB is public facing or internal


### PR DESCRIPTION
Application load balancers allows for easy redirects from http to https.
They also support http2.