### PR TITLE
Bossdbtest updates

### DIFF
--- a/bin/boss-account.py
+++ b/bin/boss-account.py
@@ -107,7 +107,7 @@ class BillingList(SubscriptionList):
 
         threshold_names = ['Billing_{}'.format(str(t)) for t in thresholds]
 
-        resp = self.client_cw.describe_alarms(AlarmNamePrefix = 'Billing_', MaxRecords=100)  # more then 100 records.
+        resp = self.client_cw.describe_alarms(AlarmNamePrefix = 'Billing_', MaxRecords=100)  # No more then 100 records will work here.
         alarm_names = [a['AlarmName'] for a in resp['MetricAlarms']]
 
         missing_alarms = 0

--- a/bin/iam_utils.py
+++ b/bin/iam_utils.py
@@ -400,7 +400,8 @@ class IamUtils(object):
                         console.error("Problem creating {}: {}".format(resource_type, resource[key]))
                         console.error("\tDetails: {}".format(str(ex)))
             else: # Currently exists, compare and update
-                console.info("Updating {} {}".format(key[:-4], resource[key]))
+                updating = False;
+                console.info("Comparing {} {}".format(key[:-4], resource[key]))
 
                 if resource['Path'] != resource_['Path']:
                     console.warning("Paths differ for {} {}: '{}' != '{}'".format(key,
@@ -413,7 +414,9 @@ class IamUtils(object):
                 if resource_type == 'groups':
                     self.group_update(resource, resource_)
                 elif resource_type == 'roles':
-                    self.role_update(resource, resource_)
+                    updating = updating or self.role_update(resource, resource_)
+                    if updating:
+                        console.info("Updating {} {}".format(key[:-4], resource[key]))
                 elif resource_type == 'policies':
                     self.policy_update(resource, resource_)
 
@@ -552,11 +555,16 @@ class IamUtils(object):
         Args:
             resource (object): Desired IAM Role definition
             resource_ (object): Current IAM Role definition
+
+        Returns:
+            (bool) role was updated.
         """
+        updating = False
         policy = json_dumps(resource['AssumeRolePolicyDocument'])
         policy_ = json_dumps(resource_['AssumeRolePolicyDocument'])
         if policy != policy_:
             console.warning('Role policy document differs')
+            updating = True
             self.iw.update_assume_role_policy(resource['RoleName'],
                                               resource['AssumeRolePolicyDocument'])
 
@@ -565,6 +573,7 @@ class IamUtils(object):
         for policy in resource['RolePolicyList']:
             policy_ = lookup.get(policy['PolicyName'])
             if policy_ is None:
+                updating = True
                 self.iw.put_role_policy(resource['RoleName'],
                                         policy['PolicyName'],
                                         policy['PolicyDocument'])
@@ -572,21 +581,25 @@ class IamUtils(object):
                 document = json_dumps(policy['PolicyDocument'])
                 document_ = json_dumps(policy_)
                 if document != document_:
+                    updating = True
                     self.iw.put_role_policy(resource['RoleName'],
                                             policy['PolicyName'],
                                             policy['PolicyDocument'])
 
         for policy in lookup.keys():
             # AWS has a policy that is not in the desired version, it should be deleted
+            updating = True
             self.iw.delete_role_policy(resource['RoleName'], policy)
 
         for arn in resource['AttachedManagedPolicies']:
             if arn not in resource_['AttachedManagedPolicies']:
+                updating = True
                 self.iw.attach_role_policy(resource["RoleName"], arn)
 
         for arn in resource_['AttachedManagedPolicies']:
             if arn not in resource['AttachedManagedPolicies']:
                 # AWS has a managed policy that is not in the desired version, it should be deleted.
+                updating = True
                 self.iw.detach_role_policy(resource["RoleName"], arn)
 
         lookup = { profile['InstanceProfileName']: profile
@@ -594,6 +607,7 @@ class IamUtils(object):
         for profile in resource['InstanceProfileList']:
             profile_ = lookup.get(profile['InstanceProfileName'])
             if profile_ is None:
+                updating = True
                 self.iw.create_instance_profile(profile['InstanceProfileName'],
                                                 profile['Path'])
                 self.iw.add_role_to_instance_profile(resource['RoleName'],
@@ -608,8 +622,11 @@ class IamUtils(object):
 
         for profile in lookup.keys():
             # AWS has an instance profile that is not in the desired version, it should be deleted
+            updating = True
             self.iw.remove_role_from_instance_profile(resource['RoleName'], profile)
             self.iw.delete_instance_profile(profile)
+
+        return updating
 
     def role_remove(self, resource):
         """Remove the referenced IAM Role

--- a/bin/iam_utils.py
+++ b/bin/iam_utils.py
@@ -324,7 +324,7 @@ class IamUtils(object):
             return group
         elif resource_type == 'roles':
             if resource['Path'].startswith('/aws-service-role/'):
-                console.warn('Cannot export AWS created Role')
+                console.warning('Cannot export AWS created Role')
                 return None
 
             role = {

--- a/cloud_formation/scenarios/mid-production.yml
+++ b/cloud_formation/scenarios/mid-production.yml
@@ -8,9 +8,9 @@ REDIS_CACHE_TYPE: cache.m5.xlarge
 REDIS_SESSION_TYPE: cache.t2.small
 REDIS_TYPE: cache.t2.small
 CACHE_MANAGER_TYPE: t3.micro
-VAULT_TYPE: t3.medium
+VAULT_TYPE: m5.large
 ACTIVITIES_TYPE: m5.large
-AUTH_TYPE: t3.large
+AUTH_TYPE: m5.xlarge
 
 # Cluster / ASG sizes
 AUTH_CLUSTER_SIZE: 1

--- a/config/iam/groups.json
+++ b/config/iam/groups.json
@@ -17,13 +17,13 @@
   },
   {
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
-      "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole",
-      "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole",
-      "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole",
       "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
       "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
-      "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+      "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole",
+      "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole",
+      "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole",
+      "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
     ],
     "GroupName": "aplCompute",
     "GroupPolicyList": [],
@@ -47,11 +47,11 @@
   },
   {
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/IAMFullAccess",
       "arn:aws:iam::==account==:policy/aplCloudFormationFullAccess",
-      "arn:aws:iam::aws:policy/CloudFrontFullAccess",
       "arn:aws:iam::aws:policy/AWSCloudTrailFullAccess",
-      "arn:aws:iam::aws:policy/AmazonVPCFullAccess"
+      "arn:aws:iam::aws:policy/AmazonVPCFullAccess",
+      "arn:aws:iam::aws:policy/CloudFrontFullAccess",
+      "arn:aws:iam::aws:policy/IAMFullAccess"
     ],
     "GroupName": "aplNetworkGroup",
     "GroupPolicyList": [],
@@ -67,8 +67,8 @@
   },
   {
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",
       "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess",
+      "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",
       "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
     ],
     "GroupName": "aplProofReader",
@@ -78,8 +78,8 @@
   {
     "AttachedManagedPolicies": [
       "arn:aws:iam::==account==:policy/aplCloudFormationFullAccess",
-      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
-      "arn:aws:iam::aws:policy/AWSSupportAccess"
+      "arn:aws:iam::aws:policy/AWSSupportAccess",
+      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
     ],
     "GroupName": "aplSWDevGroup",
     "GroupPolicyList": [],

--- a/config/iam/names-test.json
+++ b/config/iam/names-test.json
@@ -1,0 +1,9 @@
+{
+    "groups": [
+    ],
+    "roles": [
+        "CuboidImportLambdaRole"
+    ],
+    "policies": [
+    ]
+}

--- a/config/iam/names-test.json
+++ b/config/iam/names-test.json
@@ -1,9 +1,0 @@
-{
-    "groups": [
-    ],
-    "roles": [
-        "CuboidImportLambdaRole"
-    ],
-    "policies": [
-    ]
-}

--- a/config/iam/policies.json
+++ b/config/iam/policies.json
@@ -51,7 +51,6 @@
         },
         {
           "Action": [
-            "rds:*",
             "cloudwatch:DescribeAlarms",
             "cloudwatch:GetMetricStatistics",
             "ec2:DescribeAccountAttributes",
@@ -59,10 +58,11 @@
             "ec2:DescribeSecurityGroups",
             "ec2:DescribeSubnets",
             "ec2:DescribeVpcs",
-            "sns:ListSubscriptions",
-            "sns:ListTopics",
             "logs:DescribeLogStreams",
-            "logs:GetLogEvents"
+            "logs:GetLogEvents",
+            "rds:*",
+            "sns:ListSubscriptions",
+            "sns:ListTopics"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -96,18 +96,33 @@
         },
         {
           "Action": [
-            "cloudwatch:*",
             "cloudformation:*",
+            "cloudwatch:*",
             "cognito-identity:ListIdentityPools",
             "cognito-sync:GetCognitoEvents",
             "cognito-sync:SetCognitoEvents",
             "dynamodb:*",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcs",
             "events:*",
-            "iam:List*",
             "iam:Get*",
+            "iam:List*",
             "iam:ListRolePolicies",
             "iam:ListRoles",
             "iam:PassRole",
+            "iot:AttachPrincipalPolicy",
+            "iot:AttachThingPrincipal",
+            "iot:CreateKeysAndCertificate",
+            "iot:CreatePolicy",
+            "iot:CreateThing",
+            "iot:CreateTopicRule",
+            "iot:DescribeEndpoint",
+            "iot:GetTopicRule",
+            "iot:ListPolicies",
+            "iot:ListThings",
+            "iot:ListTopicRules",
+            "iot:ReplaceTopicRule",
             "kinesis:DescribeStream",
             "kinesis:ListStreams",
             "kinesis:PutRecord",
@@ -118,22 +133,7 @@
             "sns:ListSubscriptionsByTopic",
             "sns:ListTopics",
             "sns:Subscribe",
-            "sns:Unsubscribe",
-            "ec2:DescribeVpcs",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeSecurityGroups",
-            "iot:GetTopicRule",
-            "iot:ListTopicRules",
-            "iot:CreateTopicRule",
-            "iot:ReplaceTopicRule",
-            "iot:AttachPrincipalPolicy",
-            "iot:AttachThingPrincipal",
-            "iot:CreateKeysAndCertificate",
-            "iot:CreatePolicy",
-            "iot:CreateThing",
-            "iot:ListPolicies",
-            "iot:ListThings",
-            "iot:DescribeEndpoint"
+            "sns:Unsubscribe"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -150,7 +150,6 @@
         },
         {
           "Action": [
-            "dynamodb:*",
             "cloudwatch:DeleteAlarms",
             "cloudwatch:DescribeAlarmHistory",
             "cloudwatch:DescribeAlarms",
@@ -167,22 +166,23 @@
             "datapipeline:ListPipelines",
             "datapipeline:PutPipelineDefinition",
             "datapipeline:QueryObjects",
+            "dynamodb:*",
             "iam:ListRoles",
+            "lambda:CreateEventSourceMapping",
+            "lambda:CreateFunction",
+            "lambda:DeleteEventSourceMapping",
+            "lambda:DeleteFunction",
+            "lambda:GetFunctionConfiguration",
+            "lambda:ListEventSourceMappings",
+            "lambda:ListFunctions",
             "sns:CreateTopic",
             "sns:DeleteTopic",
             "sns:ListSubscriptions",
             "sns:ListSubscriptionsByTopic",
             "sns:ListTopics",
-            "sns:Subscribe",
-            "sns:Unsubscribe",
             "sns:SetTopicAttributes",
-            "lambda:CreateFunction",
-            "lambda:ListFunctions",
-            "lambda:ListEventSourceMappings",
-            "lambda:CreateEventSourceMapping",
-            "lambda:DeleteEventSourceMapping",
-            "lambda:GetFunctionConfiguration",
-            "lambda:DeleteFunction"
+            "sns:Subscribe",
+            "sns:Unsubscribe"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -231,11 +231,26 @@
             "cognito-sync:GetCognitoEvents",
             "cognito-sync:SetCognitoEvents",
             "dynamodb:*",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcs",
             "events:*",
             "iam:ListAttachedRolePolicies",
             "iam:ListRolePolicies",
             "iam:ListRoles",
             "iam:PassRole",
+            "iot:AttachPrincipalPolicy",
+            "iot:AttachThingPrincipal",
+            "iot:CreateKeysAndCertificate",
+            "iot:CreatePolicy",
+            "iot:CreateThing",
+            "iot:CreateTopicRule",
+            "iot:DescribeEndpoint",
+            "iot:GetTopicRule",
+            "iot:ListPolicies",
+            "iot:ListThings",
+            "iot:ListTopicRules",
+            "iot:ReplaceTopicRule",
             "kinesis:DescribeStream",
             "kinesis:ListStreams",
             "kinesis:PutRecord",
@@ -246,22 +261,7 @@
             "sns:ListSubscriptionsByTopic",
             "sns:ListTopics",
             "sns:Subscribe",
-            "sns:Unsubscribe",
-            "ec2:DescribeVpcs",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeSecurityGroups",
-            "iot:GetTopicRule",
-            "iot:ListTopicRules",
-            "iot:CreateTopicRule",
-            "iot:ReplaceTopicRule",
-            "iot:AttachPrincipalPolicy",
-            "iot:AttachThingPrincipal",
-            "iot:CreateKeysAndCertificate",
-            "iot:CreatePolicy",
-            "iot:CreateThing",
-            "iot:ListPolicies",
-            "iot:ListThings",
-            "iot:DescribeEndpoint"
+            "sns:Unsubscribe"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -284,8 +284,8 @@
           "Action": [
             "logs:CreateLogGroup",
             "logs:CreateLogStream",
-            "logs:PutLogEvents",
-            "logs:DescribeLogStreams"
+            "logs:DescribeLogStreams",
+            "logs:PutLogEvents"
           ],
           "Effect": "Allow",
           "Resource": [
@@ -354,9 +354,9 @@
         },
         {
           "Action": [
-            "s3:PutObject",
+            "s3:DeleteObject",
             "s3:GetObject",
-            "s3:DeleteObject"
+            "s3:PutObject"
           ],
           "Effect": "Allow",
           "Resource": [
@@ -374,7 +374,6 @@
       "Statement": [
         {
           "Action": [
-            "dynamodb:*",
             "cloudwatch:DeleteAlarms",
             "cloudwatch:DescribeAlarmHistory",
             "cloudwatch:DescribeAlarms",
@@ -391,22 +390,23 @@
             "datapipeline:ListPipelines",
             "datapipeline:PutPipelineDefinition",
             "datapipeline:QueryObjects",
+            "dynamodb:*",
             "iam:ListRoles",
+            "lambda:CreateEventSourceMapping",
+            "lambda:CreateFunction",
+            "lambda:DeleteEventSourceMapping",
+            "lambda:DeleteFunction",
+            "lambda:GetFunctionConfiguration",
+            "lambda:ListEventSourceMappings",
+            "lambda:ListFunctions",
             "sns:CreateTopic",
             "sns:DeleteTopic",
             "sns:ListSubscriptions",
             "sns:ListSubscriptionsByTopic",
             "sns:ListTopics",
-            "sns:Subscribe",
-            "sns:Unsubscribe",
             "sns:SetTopicAttributes",
-            "lambda:CreateFunction",
-            "lambda:ListFunctions",
-            "lambda:ListEventSourceMappings",
-            "lambda:CreateEventSourceMapping",
-            "lambda:DeleteEventSourceMapping",
-            "lambda:GetFunctionConfiguration",
-            "lambda:DeleteFunction"
+            "sns:Subscribe",
+            "sns:Unsubscribe"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -418,7 +418,6 @@
         },
         {
           "Action": [
-            "rds:*",
             "cloudwatch:DescribeAlarms",
             "cloudwatch:GetMetricStatistics",
             "ec2:DescribeAccountAttributes",
@@ -426,10 +425,11 @@
             "ec2:DescribeSecurityGroups",
             "ec2:DescribeSubnets",
             "ec2:DescribeVpcs",
-            "sns:ListSubscriptions",
-            "sns:ListTopics",
             "logs:DescribeLogStreams",
-            "logs:GetLogEvents"
+            "logs:GetLogEvents",
+            "rds:*",
+            "sns:ListSubscriptions",
+            "sns:ListTopics"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -481,15 +481,15 @@
       "Statement": [
         {
           "Action": [
-            "sns:*",
-            "iam:*",
-            "rds:*",
-            "s3:*",
-            "lambda:*",
             "cloudformation:*",
             "dynamodb:*",
             "ec2:*",
-            "elasticloadbalancing:*"
+            "elasticloadbalancing:*",
+            "iam:*",
+            "lambda:*",
+            "rds:*",
+            "s3:*",
+            "sns:*"
           ],
           "Effect": "Allow",
           "Resource": "*",
@@ -562,8 +562,8 @@
         },
         {
           "Action": [
-            "ec2:DescribeNetworkInterfaces",
-            "ec2:DeleteNetworkInterface"
+            "ec2:DeleteNetworkInterface",
+            "ec2:DescribeNetworkInterfaces"
           ],
           "Effect": "Allow",
           "Resource": "arn:aws:ec2:==region==:==account==:network-interface/*"
@@ -579,13 +579,13 @@
       "Statement": [
         {
           "Action": [
-            "dynamodb:DescribeTable",
-            "dynamodb:UpdateTable",
-            "cloudwatch:PutMetricAlarm",
+            "cloudwatch:DeleteAlarms",
             "cloudwatch:DescribeAlarms",
             "cloudwatch:GetMetricStatistics",
+            "cloudwatch:PutMetricAlarm",
             "cloudwatch:SetAlarmState",
-            "cloudwatch:DeleteAlarms"
+            "dynamodb:DescribeTable",
+            "dynamodb:UpdateTable"
           ],
           "Effect": "Allow",
           "Resource": "*"
@@ -626,12 +626,12 @@
         {
           "Effect": "Allow",
           "NotAction": [
-            "iam:*",
             "aws-portal:*",
-            "ses:*",
+            "devicefarm:*",
+            "iam:*",
             "iot:",
             "mobileanalytics:*",
-            "devicefarm:*",
+            "ses:*",
             "sns:*",
             "zocalo:*"
           ],
@@ -672,9 +672,9 @@
       "Statement": [
         {
           "Action": [
-            "sns:*",
-            "ec2:*",
             "cloudformation:*",
+            "ec2:*",
+            "sns:*",
             "sqs:*"
           ],
           "Effect": "Allow",
@@ -692,19 +692,19 @@
       "Statement": [
         {
           "Action": [
-            "dynamodb:PutItem",
-            "lambda:InvokeFunction",
             "dynamodb:DeleteItem",
+            "dynamodb:GetItem",
+            "dynamodb:PutItem",
             "dynamodb:Query",
             "dynamodb:UpdateItem",
-            "s3:ListBucket",
+            "lambda:InvokeFunction",
             "logs:CreateLogGroup",
-            "logs:PutLogEvents",
-            "s3:PutObject",
-            "s3:GetObject",
             "logs:CreateLogStream",
-            "sns:Publish",
-            "dynamodb:GetItem"
+            "logs:PutLogEvents",
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:PutObject",
+            "sns:Publish"
           ],
           "Effect": "Allow",
           "Resource": "*",
@@ -712,14 +712,14 @@
         },
         {
           "Action": [
+            "sqs:CreateQueue",
             "sqs:DeleteMessage",
             "sqs:DeleteMessageBatch",
-            "sqs:SendMessageBatch",
-            "sqs:ReceiveMessage",
             "sqs:DeleteQueue",
-            "sqs:SendMessage",
             "sqs:GetQueueAttributes",
-            "sqs:CreateQueue"
+            "sqs:ReceiveMessage",
+            "sqs:SendMessage",
+            "sqs:SendMessageBatch"
           ],
           "Effect": "Allow",
           "Resource": "arn:aws:sqs:*:*:downsample-*",
@@ -736,23 +736,23 @@
       "Statement": [
         {
           "Action": [
-            "dynamodb:DescribeLimits",
-            "dynamodb:DescribeTimeToLive",
-            "dynamodb:ListTagsOfResource",
-            "dynamodb:DescribeReservedCapacityOfferings",
-            "dynamodb:DescribeReservedCapacity",
-            "dynamodb:ListTables",
             "dynamodb:BatchGetItem",
             "dynamodb:BatchWriteItem",
             "dynamodb:CreateTable",
             "dynamodb:DeleteItem",
+            "dynamodb:DescribeLimits",
+            "dynamodb:DescribeReservedCapacity",
+            "dynamodb:DescribeReservedCapacityOfferings",
+            "dynamodb:DescribeTable",
+            "dynamodb:DescribeTimeToLive",
             "dynamodb:GetItem",
             "dynamodb:GetRecords",
+            "dynamodb:ListTables",
+            "dynamodb:ListTagsOfResource",
             "dynamodb:PutItem",
             "dynamodb:Query",
-            "dynamodb:UpdateItem",
             "dynamodb:Scan",
-            "dynamodb:DescribeTable"
+            "dynamodb:UpdateItem"
           ],
           "Effect": "Allow",
           "Resource": [
@@ -764,8 +764,8 @@
           "Action": [
             "ec2:DescribeInstances",
             "iam:GetInstanceProfile",
-            "iam:GetUser",
-            "iam:GetRole"
+            "iam:GetRole",
+            "iam:GetUser"
           ],
           "Effect": "Allow",
           "Resource": "*",

--- a/config/iam/roles.json
+++ b/config/iam/roles.json
@@ -751,8 +751,6 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::==account==:policy/service-role/AWSLambdaTracerAccessExecutionRole-683aea08-9fc8-4468-adfc-7d4af2c826bc",
-      "arn:aws:iam::==account==:policy/service-role/AWSLambdaTracerAccessExecutionRole-ff12834d-2eb4-44cb-9130-1ce3a86f1b76",
       "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess"
     ],
     "InstanceProfileList": [],

--- a/config/iam/roles.json
+++ b/config/iam/roles.json
@@ -840,7 +840,9 @@
     "AttachedManagedPolicies": [
       "arn:aws:iam::aws:policy/AWSLambdaExecute",
       "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+      "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
+      "arn:aws:iam::aws:policy/AmazonRoute53FullAccess"
     ],
     "InstanceProfileList": [],
     "Path": "/",

--- a/config/iam/roles.json
+++ b/config/iam/roles.json
@@ -13,11 +13,11 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/service-role/AWSQuickSightListIAM",
-      "arn:aws:iam::==account==:policy/aplPopulateUploadQueue",
       "arn:aws:iam::==account==:policy/aplDeleteCuboid",
+      "arn:aws:iam::==account==:policy/aplPopulateUploadQueue",
       "arn:aws:iam::==account==:policy/aplResolutionHierarchy",
-      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess"
+      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess",
+      "arn:aws:iam::aws:policy/service-role/AWSQuickSightListIAM"
     ],
     "InstanceProfileList": [
       {
@@ -69,8 +69,8 @@
       "Version": "2008-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier",
       "arn:aws:iam::aws:policy/AWSElasticBeanstalkMulticontainerDocker",
+      "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier",
       "arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier"
     ],
     "InstanceProfileList": [
@@ -171,11 +171,11 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AmazonSQSFullAccess",
       "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
-      "arn:aws:iam::aws:policy/AmazonS3FullAccess",
       "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
-      "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
+      "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+      "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
+      "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
     ],
     "InstanceProfileList": [
       {
@@ -332,16 +332,16 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AmazonSQSFullAccess",
+      "arn:aws:iam::==account==:policy/aplVaultPolicy",
       "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
-      "arn:aws:iam::aws:policy/IAMFullAccess",
+      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess",
+      "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
       "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess",
       "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-      "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
-      "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
       "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
-      "arn:aws:iam::==account==:policy/aplVaultPolicy",
-      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess"
+      "arn:aws:iam::aws:policy/AmazonSQSFullAccess",
+      "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
+      "arn:aws:iam::aws:policy/IAMFullAccess"
     ],
     "InstanceProfileList": [
       {
@@ -368,12 +368,12 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
       "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
-      "arn:aws:iam::aws:policy/service-role/CloudWatchEventsBuiltInTargetExecutionAccess",
+      "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+      "arn:aws:iam::aws:policy/CloudWatchEventsFullAccess",
       "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
       "arn:aws:iam::aws:policy/service-role/AWSLambdaRole",
-      "arn:aws:iam::aws:policy/CloudWatchEventsFullAccess"
+      "arn:aws:iam::aws:policy/service-role/CloudWatchEventsBuiltInTargetExecutionAccess"
     ],
     "InstanceProfileList": [],
     "Path": "/",
@@ -461,9 +461,9 @@
     },
     "AttachedManagedPolicies": [
       "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+      "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
       "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess",
-      "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-      "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
+      "arn:aws:iam::aws:policy/AmazonS3FullAccess"
     ],
     "InstanceProfileList": [],
     "Path": "/",
@@ -582,14 +582,14 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/AmazonSQSFullAccess",
       "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess",
+      "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
       "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess",
       "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-      "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
-      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
       "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
-      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess"
+      "arn:aws:iam::aws:policy/AmazonSQSFullAccess",
+      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
     ],
     "InstanceProfileList": [],
     "Path": "/",
@@ -669,8 +669,8 @@
           "Statement": [
             {
               "Action": [
-                "s3:GetBucketPolicy",
                 "s3:GetBucketLocation",
+                "s3:GetBucketPolicy",
                 "s3:ListBucketMultipartUploads"
               ],
               "Effect": "Allow",
@@ -678,9 +678,9 @@
             },
             {
               "Action": [
-                "s3:PutObject",
                 "s3:AbortMultipartUpload",
                 "s3:ListMultipartUploadParts",
+                "s3:PutObject",
                 "s3:PutObjectAcl"
               ],
               "Effect": "Allow",
@@ -707,8 +707,8 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::==account==:policy/service-role/AWSLambdaS3ExecutionRole-2a0110ca-6e60-4f94-8510-fdaf9ddfb583",
-      "arn:aws:iam::==account==:policy/service-role/AWSLambdaBasicExecutionRole-28085153-2e10-4740-8166-7090f779f1c7"
+      "arn:aws:iam::==account==:policy/service-role/AWSLambdaBasicExecutionRole-28085153-2e10-4740-8166-7090f779f1c7",
+      "arn:aws:iam::==account==:policy/service-role/AWSLambdaS3ExecutionRole-2a0110ca-6e60-4f94-8510-fdaf9ddfb583"
     ],
     "InstanceProfileList": [],
     "Path": "/service-role/",
@@ -729,8 +729,8 @@
       "Version": "2012-10-17"
     },
     "AttachedManagedPolicies": [
-      "arn:aws:iam::aws:policy/service-role/AWSLambdaRole",
-      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess"
+      "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess",
+      "arn:aws:iam::aws:policy/service-role/AWSLambdaRole"
     ],
     "InstanceProfileList": [],
     "Path": "/service-role/",
@@ -815,8 +815,8 @@
     },
     "AttachedManagedPolicies": [
       "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",
-      "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
       "arn:aws:iam::aws:policy/AmazonRoute53FullAccess",
+      "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
       "arn:aws:iam::aws:policy/service-role/AWSLambdaRole"
     ],
     "InstanceProfileList": [],
@@ -851,10 +851,10 @@
           "Statement": [
             {
               "Action": [
+                "autoscaling:SetInstanceHealth",
                 "ec2:DescribeInstances",
-                "route53:ListHostedZones",
                 "route53:ChangeResourceRecordSets",
-                "autoscaling:SetInstanceHealth"
+                "route53:ListHostedZones"
               ],
               "Effect": "Allow",
               "Resource": "*",


### PR DESCRIPTION
Added Derek's Fix to iam_utils to sort all arrays and fix for roles.
boss-account.py can now delete all threshold billing alarms in the account.
removed AWSLambdaTracerAccessExecutionRole
added a quickfix for SNS and Route53 to the VaultConsulHealthChecker role giving FULL Access
(created a JIRA ticket for figure out the correct permissions, instead of FULL)
