### PR TITLE
Migrated lambdas running Python 2.7 to 3.7

### DIFF
--- a/cloud_formation/configs/activities.py
+++ b/cloud_formation/configs/activities.py
@@ -176,6 +176,7 @@ def create_config(bosslet_config, lookup=True):
                       lambda_role,
                       const.DOWNSAMPLE_DLQ_LAMBDA,
                       handler='index.handler',
+                      runtime='python3.7',
                       timeout=10)
 
     config.add_lambda_permission('DownsampleDLQLambdaExecute',

--- a/cloud_formation/configs/cloudwatch.py
+++ b/cloud_formation/configs/cloudwatch.py
@@ -70,6 +70,7 @@ def create_config(bosslet_config):
                       security_groups=[internal_sg],
                       subnets=lambda_subnets,
                       handler='index.lambda_handler',
+                      runtime='python3.7',
                       file=const.VAULT_LAMBDA)
 
     # Lambda input data

--- a/cloud_formation/configs/core.py
+++ b/cloud_formation/configs/core.py
@@ -210,6 +210,7 @@ def create_config(bosslet_config):
                       const.DNS_LAMBDA,
                       handler="index.handler",
                       timeout=10,
+                      runtime='python3.7',
                       depends_on="DNSZone")
 
     config.add_lambda_permission("DNSLambdaExecute", Ref("DNSLambda"))

--- a/cloud_formation/lambda/monitors/chk_vault.py
+++ b/cloud_formation/lambda/monitors/chk_vault.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 from datetime import datetime
-from urllib2 import urlopen, HTTPError
 import json
 import boto3
+from urllib.request import urlopen
+from urllib.error import HTTPError
+
 
 PROTOCOL = 'http://'
 PORT = ':8200'

--- a/lib/cloudformation.py
+++ b/lib/cloudformation.py
@@ -1886,7 +1886,7 @@ class CloudFormationConfiguration:
             })
 
 
-    def add_lambda(self, key, name, role, file=None, handler=None, s3=None, description="", memory=128, timeout=3, security_groups=None, subnets=None, depends_on=None, runtime="python2.7", reserved_executions=None, dlq=None, layers=None):
+    def add_lambda(self, key, name, role, file=None, handler=None, s3=None, description="", memory=128, timeout=3, security_groups=None, subnets=None, depends_on=None, runtime="python3.7", reserved_executions=None, dlq=None, layers=None):
         """Create a Python Lambda
 
         Args:
@@ -1905,7 +1905,7 @@ class CloudFormationConfiguration:
             subnets (None|list) : List of ids of subnets to grant the lambda access to
             depends_on (None|str|list) : A unique name or list of unique names of resources within the
                                             configuration and is used to determine the launch order of resources
-            runtime (optional[str]) : Lambda runtime to use.  Defaults to "python2.7".  Ignored if handler is not None, but file and s3 are None.
+            runtime (optional[str]) : Lambda runtime to use.  Defaults to "python3.7".  Ignored if handler is not None, but file and s3 are None.
             reserved_executions (optional[int]): Number of reserved concurrent executions for the lambda.
             dlq (optional[str]): ARN of dead letter queue.  Defaults to None.
             layers (optional[list[str]]): List of lambda layer ARNs with version

--- a/lib/cloudformation.py
+++ b/lib/cloudformation.py
@@ -1905,7 +1905,7 @@ class CloudFormationConfiguration:
             subnets (None|list) : List of ids of subnets to grant the lambda access to
             depends_on (None|str|list) : A unique name or list of unique names of resources within the
                                             configuration and is used to determine the launch order of resources
-            runtime (optional[str]) : Lambda runtime to use.  Defaults to "python2.7".
+            runtime (optional[str]) : Lambda runtime to use.  Defaults to "python2.7".  Ignored if handler is not None, but file and s3 are None.
             reserved_executions (optional[int]): Number of reserved concurrent executions for the lambda.
             dlq (optional[str]): ARN of dead letter queue.  Defaults to None.
             layers (optional[list[str]]): List of lambda layer ARNs with version


### PR DESCRIPTION
* chk_vault lambda.
* DNS lambda.
* downsample-dlq lambda

Only chk_vault lambda required actual code changes for the migration.