### PR TITLE
Autoscaling for Vault Table

### DIFF
--- a/cloud_formation/dynamodb-autoscale/BossProductionProvisioners.json
+++ b/cloud_formation/dynamodb-autoscale/BossProductionProvisioners.json
@@ -358,5 +358,65 @@
             }
           }
         }
-    }
+    },
+    "vault_cfg": {
+      "ReadCapacity": {
+        "Min": 5,
+        "Max": 40000,
+        "Increment": {
+          "When": {
+            "UtilisationIsAbovePercent": 75,
+            "ThrottledEventsPerMinuteIsAbove": 25
+          },
+          "By": {
+            "Units": 3,
+            "ProvisionedPercent": 30,
+            "ThrottledEventsWithMultiplier": 0.7
+          },
+          "To": {
+            "ConsumedPercent": 130
+          }
+        },
+        "Decrement": {
+          "When": {
+            "UtilisationIsBelowPercent": 30,
+            "AfterLastIncrementMinutes": 60,
+            "AfterLastDecrementMinutes": 60,
+            "UnitAdjustmentGreaterThan": 5
+          },
+          "To": {
+            "ConsumedPercent": 100
+          }
+        }
+      },
+      "WriteCapacity": {
+        "Min": 5,
+        "Max": 40000,
+        "Increment": {
+          "When": {
+            "UtilisationIsAbovePercent": 75,
+            "ThrottledEventsPerMinuteIsAbove": 25
+          },
+          "By": {
+            "Units": 3,
+            "ProvisionedPercent": 30,
+            "ThrottledEventsWithMultiplier": 0.7
+          },
+          "To": {
+            "ConsumedPercent": 130
+          }
+        },
+        "Decrement": {
+          "When": {
+            "UtilisationIsBelowPercent": 30,
+            "AfterLastIncrementMinutes": 60,
+            "AfterLastDecrementMinutes": 60,
+            "UnitAdjustmentGreaterThan": 5
+          },
+          "To": {
+            "ConsumedPercent": 100
+          }
+        }
+      }
+  }
 }

--- a/cloud_formation/dynamodb-autoscale/BossTableConfig.json
+++ b/cloud_formation/dynamodb-autoscale/BossTableConfig.json
@@ -3,5 +3,6 @@
     "idCount": "idCount_cfg",
     "idIndex": "idIndex_cfg",
     "s3index": "s3index_cfg",
-    "tileindex": "tileindex_cfg"
+    "tileindex": "tileindex_cfg",
+    "vault": "vault_cfg"
 }


### PR DESCRIPTION
Adds autoscaling to vault table using dynamo-lambda. Mirrors the same rule set as tileIndex table. 

