### PR TITLE
fixed lambas.py so passed in dict rather then string

### DIFF
--- a/lib/lambdas.py
+++ b/lib/lambdas.py
@@ -200,7 +200,7 @@ def update_lambda_code(bosslet_config):
             resp = client.update_function_code(
                 FunctionName=lambda_name,
                 S3Bucket=bosslet_config.LAMBDA_BUCKET,
-                S3Key=code_zip(bosslet_config, config['name']),
+                S3Key=code_zip(bosslet_config, config),
                 Publish=True)
             print(resp)
         except botocore.exceptions.ClientError as ex:


### PR DESCRIPTION
code_zip requires the config dict be passed instead of the single string.
Tested function and it worked after the change was made.
This code allows someone to update the multilambda zip file code then refresh all the lambdas that reference multilambda.