### PR TITLE
fixed directory where ndingest needs to be installed on ubuntu20.04 with python3.8

### DIFF
--- a/salt_stack/salt/ndingest/init.sls
+++ b/salt_stack/salt/ndingest/init.sls
@@ -5,7 +5,7 @@ include:
 
 ndingest-lib:
     file.recurse:
-        - name: /usr/lib/python3/dist-packages/ndingest
+        - name: /usr/local/lib/python3.8/dist-packages/ndingest
         - source: salt://ndingest/files/ndingest.git
         - include_empty: true
         - user: root


### PR DESCRIPTION
changed the init.sls to install ndingest to python3.8 location on ubuntu20.04
Without this change the tests were failing to run with pytest
