### PR TITLE
updated hardcoded location for ndingest in salt stack build settings file

### DIFF
--- a/salt_stack/salt/ndingest/build_settings.py
+++ b/salt_stack/salt/ndingest/build_settings.py
@@ -22,7 +22,7 @@ import urllib.request
 from spdb.c_lib.ndtype import CUBOIDSIZE
 
 # Location of settings files for ndingest.
-NDINGEST_SETTINGS_FOLDER = '/usr/lib/python3/dist-packages/ndingest/settings'
+NDINGEST_SETTINGS_FOLDER = '/usr/local/lib/python3.8/dist-packages/ndingest/settings'
 
 # Template used for ndingest settings.ini generation.
 NDINGEST_SETTINGS_TEMPLATE = NDINGEST_SETTINGS_FOLDER + '/settings.ini.apl'


### PR DESCRIPTION
ndingest location in salt build settings file was now pointing to the wrong location after updating to python3.8 and Ubuntu 20.04.