### PR TITLE
Add new SQS queue for id indexing.

### DIFF
--- a/bin/run_indexing.py
+++ b/bin/run_indexing.py
@@ -149,7 +149,10 @@ def get_common_args(bosslet_config):
         },
         "max_write_id_index_lambdas": 599,
         "max_cuboid_fanout": 30,
-        "max_items": 100
+        "max_items": 100,
+        "sqs_url": f'https://queue.amazonaws.com/{account}/{n.index_ids_queue}' ,
+        # Number of object ids to include in a single SQS message.
+        "num_ids_per_msg": 20,
     }
 
     return common_args

--- a/cloud_formation/configs/idindexing.py
+++ b/cloud_formation/configs/idindexing.py
@@ -136,6 +136,10 @@ def create_config(bosslet_config):
                "load_ids_from_s3_lambda.handler",
                timeout=120, memory=128)
 
+    max_receives = 3
+    config.add_sqs_queue(names.index_ids_queue.sqs, names.index_ids_queue.sqs, 120,
+                         20160, dead=(aws.sqs_lookup_arn(session, names.index_deadletter.sqs), max_receives))
+
     return config
 
 

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -743,6 +743,24 @@ def sqs_delete_all(session, domain):
     for url in resp.get('QueueUrls', []):
         client.delete_queue(QueueUrl=url)
 
+def sqs_lookup_arn(session, queue_name):
+    """Lookup up SQS arn given a name.
+
+    Args:
+        session (Session) : Boto3 session used to lookup information in AWS.
+        queue_name (string) : Name of the queue to lookup.
+
+    Returns:
+        (string) : ARN for the queue.
+
+    Raises:
+        (boto3.ClientError): If queue not found.
+    """
+    client = session.client('sqs')
+    url = sqs_lookup_url(session, queue_name)
+    resp = client.get_queue_attributes(QueueUrl=url, AttributeNames=['QueueArn'])
+    return resp['Attributes']['QueueArn']
+
 def sqs_lookup_url(session, queue_name):
     """Lookup up SQS url given a name.
 

--- a/lib/names.py
+++ b/lib/names.py
@@ -245,6 +245,8 @@ class AWSNames(object):
                                'types': ['lambda_', 'sfn']},
         'index_get_num_cuboid_keys_msgs': {'name': 'indexGetNumCuboidKeysMsgsLambda',
                                            'type': 'lambda_'},
+        'index_ids_queue': {'name': 'indexIdsQueue',
+                            'type': 'sqs'},
         'index_id_writer': {'name': 'Index.IdWriter',
                             'type': 'sfn'},
         'index_invoke_index_supervisor': {'name': 'indexInvokeIndexSupervisorLambda',


### PR DESCRIPTION
Object ids will now be stored in a queue so we can hook the queue up to
a lambda for draining. This PR adds the queue to the `idindexing`
Cloudformation config and connects it to the existing indexing dead letter queue.