### PR TITLE
Throttling models

### DIFF
--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -77,10 +77,6 @@ def create_config(bosslet_config, db_config={}):
     else:
         # Don't create a Redis server for dev stacks.
         user_data["aws"]["cache-session"] = ''
-    if const.REDIS_THROTTLE_TYPE is not None:
-        user_data["aws"]["cache-throttle"] = names.cache_throttle.redis
-    else:
-        user_data["aws"]["cache-throttle"] = ''
 
     ## cache-db and cache-stat-db need to be in user_data for lambda to access them.
     user_data["aws"]["cache-db"] = "0"
@@ -290,7 +286,6 @@ def create(bosslet_config):
     with bosslet_config.call.vault() as vault:
         vault.write(const.VAULT_ENDPOINT, secret_key = str(uuid.uuid4()))
         vault.write(const.VAULT_ENDPOINT_DB, **db_config)
-        vault.write(const.VAULT_ENDPOINT_THROTTLE, config = json.dumps(const.THROTTLE))
 
         dns = bosslet_config.names.public_dns("api")
         uri = "https://{}".format(dns)
@@ -387,11 +382,6 @@ def update(bosslet_config):
     config = create_config(bosslet_config, db_config)
 
     config.update()
-
-    # DP NOTE: If there is a migration error then throttling will not be updated...
-    print("Updating Throttling Config")
-    with bosslet_config.call.vault() as vault:
-        vault.write(const.VAULT_ENDPOINT_THROTTLE, config = json.dumps(const.THROTTLE))
 
 def delete(bosslet_config):
     session = bosslet_config.session

--- a/cloud_formation/scenarios/dev-with-throttling.yml
+++ b/cloud_formation/scenarios/dev-with-throttling.yml
@@ -3,7 +3,6 @@ ENDPOINT_TYPE: t2.medium
 RDS_TYPE: db.t2.micro
 REDIS_CACHE_TYPE: cache.t2.small
 REDIS_SESSION_TYPE: null # Not used for dev
-REDIS_THROTTLE_TYPE: cache.t2.small # Now testing
 REDIS_TYPE: cache.t2.small
 CACHE_MANAGER_TYPE: t2.micro
 VAULT_TYPE: t3.micro
@@ -20,22 +19,3 @@ REDIS_CLUSTER_SIZE: 1
 # Memory Size
 REDIS_RESERVED_MEMORY_PERCENT: 25
 
-# Throttle Configuration
-THROTTLE:
-    system: 
-        egress: null
-        ingress: null
-    apis:
-        cutout:
-            egress: null
-            ingress: null
-        image:
-            egress: null
-        tile:
-            egress: null
-    users:
-        bossadmin: 
-            egress: null
-    groups:
-        public:
-            egress: null 

--- a/cloud_formation/scenarios/development.yml
+++ b/cloud_formation/scenarios/development.yml
@@ -3,7 +3,6 @@ ENDPOINT_TYPE: t2.medium
 RDS_TYPE: db.t2.micro
 REDIS_CACHE_TYPE: cache.t2.small
 REDIS_SESSION_TYPE: null # Not used for dev
-REDIS_THROTTLE_TYPE: null # Not used for dev
 REDIS_TYPE: cache.t2.small
 CACHE_MANAGER_TYPE: t2.micro
 VAULT_TYPE: t3.micro

--- a/cloud_formation/scenarios/ha-development.yml
+++ b/cloud_formation/scenarios/ha-development.yml
@@ -3,7 +3,6 @@ ENDPOINT_TYPE: t2.medium
 RDS_TYPE: db.t2.micro
 REDIS_CACHE_TYPE: cache.t2.small
 REDIS_SESSION_TYPE: cache.t2.small
-REDIS_THROTTLE_TYPE: cache.t2.small
 REDIS_TYPE: cache.t2.small
 CACHE_MANAGER_TYPE: t2.micro
 VAULT_TYPE: t3.large
@@ -19,16 +18,3 @@ REDIS_CLUSTER_SIZE: 1
 
 # Memory Size
 REDIS_RESERVED_MEMORY_PERCENT: 25
-
-# Throttle Configuration
-THROTTLE:
-    system: null
-    apis:
-        cutout_egress: null
-        cutout_ingress: null
-        image_egress: null
-        tile_egress: null
-    users:
-        bossadmin: null
-    groups:
-        public: null

--- a/cloud_formation/scenarios/production.yml
+++ b/cloud_formation/scenarios/production.yml
@@ -3,7 +3,6 @@ ENDPOINT_TYPE: m5.2xlarge
 RDS_TYPE: db.t2.medium
 REDIS_CACHE_TYPE: cache.m4.2xlarge
 REDIS_SESSION_TYPE: cache.t2.medium
-REDIS_THROTTLE_TYPE: cache.t2.medium
 REDIS_TYPE: cache.m5.xlarge
 CACHE_MANAGER_TYPE: t2.medium
 VAULT_TYPE: m5.large
@@ -19,23 +18,3 @@ REDIS_CLUSTER_SIZE: 2
 
 # Memory Size
 REDIS_RESERVED_MEMORY_PERCENT: 25
-
-# Throttle Configuration
-THROTTLE:
-    system: 
-        egress: null
-        ingress: null
-    apis:
-        cutout:
-            egress: null
-            ingress: null
-        image:
-            egress: null
-        tile:
-            egress: null
-    users:
-        bossadmin: 
-            egress: null
-    groups:
-        public: 
-            egress: null

--- a/cloud_formation/scenarios/scenario.yml.example
+++ b/cloud_formation/scenarios/scenario.yml.example
@@ -7,7 +7,6 @@ ENDPOINT_TYPE:       # EC2 Instance Type
 RDS_TYPE:            # RDS Instance Type
 REDIS_CACHE_TYPE:    # ElastiCache Instance Type
 REDIS_SESSION_TYPE:  # ElastiCache Instance Type
-REDIS_THROTTLE_TYPE: # ElastiCache Instance Type
 REDIS_TYPE:          # ElastiCache Instance Type
 CACHE_MANAGER_TYPE:  # EC2 Instance Type
 ACTIVITIES_TYPE:     # EC2 Instance Type
@@ -24,26 +23,3 @@ REDIS_CLUSTER_SIZE:   # ElastiCache Redis Replicas
 
 # Memory Size
 REDIS_RESERVED_MEMORY_PERCENT: 25 # ElastiCache Redis Percentage of Memory that is Reserved Memory (recommended to be 25%)
-
-# Throttling
-THROTTLE:
-    # Throttle limits are
-    # null - No throttling
-    # <num><unit> - Limit to the given bytes per day
-    #               <num> is a float
-    #               <unit> is one of K, M, G, T, P for
-    #               kilobytes, megabytes, gigabytes, terabytes, petabytes
-
-    system: null # System wide throttling, allows for creating a limited stack
-    apis: # API specific throttling, allow for restricting parts of the stack
-        cutout_egress: null
-        cutout_ingress: null
-        image_egress: null
-        tile_egress: null
-    users: # User specific throttling, allowing for granting higher or lower limits
-           # then what a user's groups would grant
-        bossadmin: null
-    groups: # Group specific throttling. All groups limits that apply to a user are
-            # selected and the highest limit is used
-        public: null
-    default_user: null # Throttling if a user doesn't match users or groups

--- a/docs/APIThrottling.md
+++ b/docs/APIThrottling.md
@@ -19,7 +19,7 @@ For every threshold, there is a usage object that tracks the current usage level
 After an initial deployment, there will be no __metric types__ or __thresholds__ defined. As API calls are made, metric types, thresholds, and usage objects will be created automatically. By default, all thresholds are set to unlimited so no throttling will occur. An administrator can set the default limits using the REST API before allowing users access. This will cause automatically created thresholds to use the new default limits for metrics. 
 
 # REST API
-The metric API allows administrators to view metric types, thresholds, and usage objects. Non-admin users can only view their own usage.  Administrators can create and update metric types and thresholds. update limits. It can also be used to change the default limits for system, api, and user metrics.
+The metric API allows administrators to view metric types, thresholds, and usage objects. Non-admin users can only view their own usage objects. Administrators can create and update metric types and thresholds. A metric type can be updated to change the default limit for newly created thresholds. A threshold object can be updated to change the limit and allow a user to continue working.
 
 ## Metric Types
 Each metric type has defaults for system, api, and user level metrics. A limit of -1 means there is no limit.

--- a/docs/APIThrottling.md
+++ b/docs/APIThrottling.md
@@ -6,13 +6,87 @@ Not to be confused with AWS throttling that bossdb also supports.
 API Throttling is enforced when users or applications invoke APIs that move data or otherwise incur costs for the AWS account. Each API can check for limits by using the BossThrottle.check() method from within a view. 
 
 ## Metric Types
-There are 3 metric types supported: Ingress (bytes), Egress (bytes), and Compute (cuboids). Each API determines the metric type (mtype) and units used when performing a check. Each metric type has default limits for each level of throttling (see Thresholds).
+Each data API determines the __metric type__ (mtype) and units reported when performing a throttling check.
+Currently, there are 3 metric types defined by the boss APIs: _ingress_, _egress_, and _compute_.  Each metric type has default limits for each level of throttling (see Thresholds). The units for the metric types are fixed by the APIs.
 
 ## Thresholds
-Each threshold object is uniquely identified by a name and metric type.  The naming of the metric reflects level of the limit: system, api, or user. For example, there is a system level threshold for each possible metric type. Each threshold has limit setting. 
+Each __threshold__ object is uniquely identified by a __metric name__ and __metric type__.  The naming of the metric reflects the scope of the limit: _system_, _api_, or _user_. For example, the user johnsmith will have thresholds with metric name \"user:johnsmith\" and the cutout api will have thresholds with metric name \"api:cutout\". Thresholds for the __system__ level will have metric names \"system\". Each threshold has an integer __limit__ value. A limit of -1 will disable thresholding for this metric (name and type).
 
 ## Usage
-For every threshold, there is a usage object that tracks the current usage level and the date since that usage has been aggregated. When usage is checked, the aggregated usage will be reset to 0 if the current aggregation is for the previous month. In other words, the usage is reset to zero at the start of each month.
+For every threshold, there is a usage object that tracks the current usage level. The __value__ field is the aggregated usage. The __since__ field is the date since that usage has been aggregated. When usage is checked, the aggregated value will be cleared and the since field will be updated if the current aggregation is for the previous month. In other words, the usage is reset to zero at the start of each month. However, the value is only reset when a throttle check is made. Using the API to read the usage will not change it.
 
+# Initialization
+After an initial deployment, there will be no __metric types__ or __thresholds__ defined. As API calls are made, metric types, thresholds, and usage objects will be created automatically. By default, all thresholds are set to unlimited so no throttling will occur. An administrator can set the default limits using the REST API before allowing users access. This will cause automatically created thresholds to use the new default limits for metrics. 
 
+# REST API
+The metric API allows administrators to view metric types, thresholds, and usage objects. Non-admin users can only view their own usage.  Administrators can create and update metric types and thresholds. update limits. It can also be used to change the default limits for system, api, and user metrics.
+
+## Metric Types
+Each metric type has defaults for system, api, and user level metrics. A limit of -1 means there is no limit.
+
+Metric types can be read by an administrator using a GET https://_api-fqdn_/metric/metrics. Sample results are shown below:
+
+```json
+[ {"mtype":"egress",
+   "units":"byte_count",
+   "def_user_limit":5368709120,
+   "def_api_limit":-1,
+   "def_system_limit":-1},
+  {"mtype":"ingress",
+   "units":"byte_count",
+   "def_user_limit":10737418240,
+   "def_api_limit":-1,
+   "def_system_limit":-1} ]
+```
+
+In the above example, there are two metric types defined. The egress metric has a default user limit of 5G and the ingress metric has a default user limit of 10G. The default for system and api scope is unlimited.
+
+Metric types can be created or updated using a PUT to https://_api-fqdn_/metric/metrics. The only required field is __mtype__. The default limits are optional. The units field will be ignored. Sample data for a PUT is shown below:
+
+```json
+[{"mtype":"egress", "def_user_limit":"10G"}]
+```
+In our sample data, the default user limit for the egress metric type will be changed to 10G. The PUT command for /metric/metrics accepts strings or integer values for a limit. The string must be a number followed by an optional scalar: K, M, G, or T. Upper or lowercase is accepted.
+
+## Thresholds
+The thresholds can be read by an administrator using a GET https://_api-fqdn_/metric/thresholds. An example is shown below:
+
+```json
+[ {"metric":"user:bossadmin",
+   "mtype":"egress",
+   "units":"byte_count",
+   "limit":5368709120},
+  {"metric":"api:cutout",
+   "mtype":"egress",
+   "units":"byte_count",
+   "limit":-1} ]
+```
+An adminstrator can create or update thresholds using a PUT https://_api-fqdn_/metric/thresholds. There are two required fields: _metric_ and _mtype_. The _limit_ field is optional. If the threshold does not exist, it will be created and the limit will be set to the default for that metric type. An example is shown below:
+
+```json
+[ {"metric":"user:bossadmin",
+   "mtype":"egress",
+   "limit":"10G"}, ]
+```
+In the above example, the "user:bossadmin" _egress_ limit will be changed to 10G. 
+
+## Usage
+Finally, any user can read their usage by using a GET https://_api-fqdn_/metric/. This will show the usage for the current user. An example is shown below:
+
+```json
+[ {"metric":"user:bossadmin",
+   "mtype":"egress",
+   "units":"byte_count",
+   "limit":5368709120,
+   "since":"2020-10-21",
+   "value":8},
+  {"metric":"user:bossadmin",
+   "mtype":"ingress",
+   "units":"byte_count",
+   "limit":10737418240,
+   "since":"2020-10-21",
+   "value":1000000} ]
+```
+
+An administrator can view the usage for any metric by using a GET https://_api-fqdn_/metric/?metric=_metricname_. And the adminsistrator can get all usage data by using a GET https://_api-fqdn_/metric/usage.
 

--- a/docs/APIThrottling.md
+++ b/docs/APIThrottling.md
@@ -1,0 +1,18 @@
+# API Throttling Capability
+This capability provides for throttling at the bossdb API layer.
+Not to be confused with AWS throttling that bossdb also supports. 
+
+# Overview
+API Throttling is enforced when users or applications invoke APIs that move data or otherwise incur costs for the AWS account. Each API can check for limits by using the BossThrottle.check() method from within a view. 
+
+## Metric Types
+There are 3 metric types supported: Ingress (bytes), Egress (bytes), and Compute (cuboids). Each API determines the metric type (mtype) and units used when performing a check. Each metric type has default limits for each level of throttling (see Thresholds).
+
+## Thresholds
+Each threshold object is uniquely identified by a name and metric type.  The naming of the metric reflects level of the limit: system, api, or user. For example, there is a system level threshold for each possible metric type. Each threshold has limit setting. 
+
+## Usage
+For every threshold, there is a usage object that tracks the current usage level and the date since that usage has been aggregated. When usage is checked, the aggregated usage will be reset to 0 if the current aggregation is for the previous month. In other words, the usage is reset to zero at the start of each month.
+
+
+

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -104,8 +104,6 @@ VAULT_KEYCLOAK_DB = "secret/keycloak/db"
 VAULT_ENDPOINT = "secret/endpoint/django"
 VAULT_ENDPOINT_DB = "secret/endpoint/django/db"
 VAULT_ENDPOINT_AUTH = "secret/endpoint/auth"
-VAULT_ENDPOINT_THROTTLE = "secret/endpoint/throttle"
-
 
 ########################
 # Service Check Timeouts
@@ -119,7 +117,6 @@ ENDPOINT_TYPE = "t2.micro"
 RDS_TYPE = "db.t2.micro"
 REDIS_CACHE_TYPE = "cache.t2.micro"
 REDIS_SESSION_TYPE = None
-REDIS_THROTTLE_TYPE = None
 REDIS_TYPE = "cache.t2.micro"
 CACHE_MANAGER_TYPE = "t2.micro"
 VAULT_TYPE = "t2.micro"
@@ -139,34 +136,6 @@ REDIS_CLUSTER_SIZE = 1
 #################
 # Resource Memory
 REDIS_RESERVED_MEMORY_PERCENT = 25
-
-########################
-# Throttle Configuration
-THROTTLE = {
-    # For system / apis if not provided no throttling will happen
-    'system': None,
-    'apis': {
-        'cutout_egress': None,
-        'cutout_ingress': None,
-        'image_egress': None,
-        'tile_egress': None,
-    },
-
-    # For a user if no rules match then no throttling will happen
-    # All matching rules are collected and the largest will be used
-    # ??? Do we want to be able to have rules where a user has a lower limit
-    #     than the groups they are apart of? (abusive user?)
-    'users': {
-        'bossadmin': None,
-    },
-    'groups': {
-        'public': None,
-    },
-
-    # user / group default?
-    # Should a more specific user / group be allowed to be lower then the default?
-}
-
 
 ########################
 # Machine Configurations

--- a/lib/lambdas.py
+++ b/lib/lambdas.py
@@ -108,8 +108,7 @@ def lambda_dirs(bosslet_config):
         n.index_load_ids_from_s3.lambda_: 'multi_lambda',
         n.downsample_volume.lambda_: 'multi_lambda',
         n.copy_cuboid_lambda.lambda_: 'multi_lambda',
-        n.dynamo_lambda.lambda_: 'dynamodb-lambda-autoscale',
-        n.cache_throttle.lambda_: 'cache_throttle',
+        n.dynamo_lambda.lambda_: 'dynamodb-lambda-autoscale'
     }
 
 def code_zip(bosslet_config, lambda_config):


### PR DESCRIPTION
Finally, after testing on bossdbtest, I am confident that my changes to boss-manage have no adverse affect on deploying the stack. Most of the changes are removing the redis cache used by the original version of throttling. Also added documentation on how to use the REST API.