### PR TITLE
HTTP/2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ packer/output/
 # Private Files
 *.pem
 *.ppk
+*.key
+*.crt
 vault/private/
 
 # Personal Vagrant files

--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -173,7 +173,7 @@ def create_config(bosslet_config, db_config={}):
     cert = aws.cert_arn_lookup(session, names.public_dns("api"))
     target_group_keys = config.add_app_loadbalancer("EndpointAppLoadBalancer",
                             names.endpoint_elb.dns,
-                            [("443", "80", "HTTPS", cert)],
+                            [("443", "443", "HTTPS", cert)],
                             vpc_id=vpc_id,
                             subnets=external_subnets_asg,
                             security_groups=[sgs[names.internal.sg], sgs[names.https.sg]],

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -53,13 +53,13 @@ sudo -E python3 manage.py test 2>&1 | tee /home/ubuntu/1_django_unittest.txt
 cd /srv/www/django
 sudo -E python3 manage.py test -- -c inttest.cfg 2>&1 | tee /home/ubuntu/2_django_inttest.txt
 
-cd /usr/local/lib/python3.5/site-packages/spdb
+cd /usr/local/lib/python3.8/dist-packages/spdb
 sudo nose2 2>&1 | tee /home/ubuntu/3_spdb_unittest.txt
 sudo nose2 -c inttest.cfg 2>&1 | tee /home/ubuntu/4_spdb_inttest.txt
 
 # Manual install for now.  Will likely remove use of pytest in the future.
 sudo -H pip3 install pytest
-cd /usr/local/lib/python3/site-packages/ndingest
+cd /usr/local/lib/python3.8/dist-packages/ndingest
 # Use randomized queue names and prepend 'test_' to bucket/index names.
 export NDINGEST_TEST=1
 pytest -c test_apl.cfg 2>&1 | tee /home/ubuntu/5_ndingest_test.txt
@@ -102,7 +102,7 @@ sudo -E python3 manage.py test -- -c inttest.cfg
 
 #### SPDB Integration Tests 
 ```shell
-cd /usr/local/lib/python3.5/site-packages/spdb
+cd /usr/local/lib/python3.8/dist-packages/spdb
 sudo nose2
 sudo nose2 -c inttest.cfg
 ```
@@ -111,7 +111,7 @@ sudo nose2 -c inttest.cfg
 ```shell
 # Manual install for now.  Will likely remove use of pytest in the future.
 sudo pip3 install pytest
-cd /usr/local/lib/python3/site-packages/ndingest
+cd /usr/local/lib/python3.8/dist-packages/ndingest
 # Use randomized queue names and prepend 'test_' to bucket/index names.
 export NDINGEST_TEST=1
 pytest -c test_apl.cfg

--- a/lib/cloudformation.py
+++ b/lib/cloudformation.py
@@ -1470,6 +1470,8 @@ class CloudFormationConfiguration:
             target_group_key = "{}TargetGroup".format(key)
             target_group_keys.append(target_group_key)
 
+            using_https = len(listener) == 4 and listener[3] is not None
+
             self.resources[target_group_key] = {
                 "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
                 "Properties": {
@@ -1479,7 +1481,7 @@ class CloudFormationConfiguration:
                     "HealthCheckTimeoutSeconds": 5,
                     "HealthyThresholdCount": 2,
                     "UnhealthyThresholdCount": 5,
-                    "Protocol": "HTTP",
+                    "Protocol": "HTTPS" if using_https else "HTTP",
                     "Port": listener[1],
                     "TargetType": "instance"
                 }
@@ -1501,7 +1503,6 @@ class CloudFormationConfiguration:
                 #"PolicyNames": [key + "Policy"],
             }
 
-            using_https = len(listener) == 4 and listener[3] is not None
             if using_https:
                 listener_props["Certificates"] = [ { "CertificateArn": listener[3] } ]
 

--- a/salt_stack/salt/boss/django.sls
+++ b/salt_stack/salt/boss/django.sls
@@ -32,11 +32,11 @@ ssl-config:
     file.managed:
         - mode: 600
         - names:
-            - /etc/ssl/certs/nginx-selfsigned.crt
+            - /etc/ssl/certs/nginx-selfsigned.crt:
                 - source: salt://boss/files/boss.git/nginx-selfsigned.crt
-            - /etc/ssl/private/nginx-selfsigned.key
+            - /etc/ssl/private/nginx-selfsigned.key:
                 - source: salt://boss/files/boss.git/nginx-selfsigned.key
-            - /etc/nginx/dhparam.pem 
+            - /etc/nginx/dhparam.pem: 
                 - source: salt://boss/files/boss.git/dhparam.pem
 
 nginx-config:
@@ -44,9 +44,9 @@ nginx-config:
         - names: 
             - /etc/nginx/sites-available/boss:
                 - source: salt://boss/files/boss.git/boss_nginx.conf
-            - /etc/nginx/snippets/self-signed.conf
+            - /etc/nginx/snippets/self-signed.conf:
                 - source: salt://boss/files/boss.git/self-signed.conf
-            - /etc/nginx/snippets/ssl-params.conf
+            - /etc/nginx/snippets/ssl-params.conf:
                 - source: salt://boss/files/boss.git/ssl-params.conf
 
 nginx-enable-config:

--- a/salt_stack/salt/boss/django.sls
+++ b/salt_stack/salt/boss/django.sls
@@ -33,11 +33,11 @@ ssl-config:
         - mode: 600
         - names:
             - /etc/ssl/certs/nginx-selfsigned.crt:
-                - source: salt://boss/files/boss.git/nginx-selfsigned.crt
+                - source: salt://boss/files/nginx-selfsigned.crt
             - /etc/ssl/private/nginx-selfsigned.key:
-                - source: salt://boss/files/boss.git/nginx-selfsigned.key
+                - source: salt://boss/files/nginx-selfsigned.key
             - /etc/nginx/dhparam.pem: 
-                - source: salt://boss/files/boss.git/dhparam.pem
+                - source: salt://boss/files/dhparam.pem
 
 nginx-config:
     file.managed:

--- a/salt_stack/salt/boss/django.sls
+++ b/salt_stack/salt/boss/django.sls
@@ -28,10 +28,26 @@ django-files:
         - source: salt://boss/files/boss.git
         - include_empty: true
 
+ssl-config:
+    file.managed:
+        - mode: 600
+        - names:
+            - /etc/ssl/certs/nginx-selfsigned.crt
+                - source: salt://boss/files/boss.git/nginx-selfsigned.crt
+            - /etc/ssl/private/nginx-selfsigned.key
+                - source: salt://boss/files/boss.git/nginx-selfsigned.key
+            - /etc/nginx/dhparam.pem 
+                - source: salt://boss/files/boss.git/dhparam.pem
+
 nginx-config:
     file.managed:
-        - name: /etc/nginx/sites-available/boss
-        - source: salt://boss/files/boss.git/boss_nginx.conf
+        - names: 
+            - /etc/nginx/sites-available/boss:
+                - source: salt://boss/files/boss.git/boss_nginx.conf
+            - /etc/nginx/snippets/self-signed.conf
+                - source: salt://boss/files/boss.git/self-signed.conf
+            - /etc/nginx/snippets/ssl-params.conf
+                - source: salt://boss/files/boss.git/ssl-params.conf
 
 nginx-enable-config:
     file.symlink:


### PR DESCRIPTION
Add HTTP/2 support to the API through a self-signed certificate. **Certificate and key files will be distributed to developers through e-mail.** 

Changelog:
- Set API ELB instance port to 443 
- Adds `HTTPS` protocol to ELB Cloud-formation library function
- Adds SSL file states to Django Salt Stack
- Updates testing.md doc

Associated PR:
- boss: https://github.com/jhuapl-boss/boss/pull/68

Endpoint Test Results:

- **django integration tests** 
  ```
  Ran 177 tests in 1105.262s
  FAILED (failures=3, skipped=5)
  ```
The three that failed are the cutout_to_black tests, fixed in https://github.com/jhuapl-boss/boss/pull/66

- **django unit tests** 
  ```
  Ran 346 tests in 416.785s
  FAILED (failures=16, errors=2, skipped=11)
  ```

Same 16 failures I was having before changing to http/2. Verifying further...


- **spdb unit tests**
  ```
  Ran 224 tests in 12.390s
  OK (skipped=3)
  ```

- **spdb integration tests**
  ```
  Ran 224 tests in 10.575s
  
  OK (skipped=3)
  ```

- **ndingest tests**
  ```
  =========================== short test summary info ============================
  FAILED test/test_bosstileindexdb.py::Test_BossTileIndexDB::test_getTaskItems_force_multiple_queries
  ============= 1 failed, 34 passed, 4 warnings in 214.22s (0:03:34) =============
  ``` 