### PR TITLE
Changed keycloak from 11.0.0 to 11.0.3

### DIFF
--- a/salt_stack/salt/keycloak/init.sls
+++ b/salt_stack/salt/keycloak/init.sls
@@ -8,13 +8,13 @@ daemon:
 download:
     file.managed:
         - name: /tmp/keycloak.tar.gz
-        - source: https://downloads.jboss.org/keycloak/11.0.0/keycloak-11.0.0.tar.gz
-        - source_hash: sha1=398a328a180682ee58b06df148938f5de710f89f
+        - source: https://downloads.jboss.org/keycloak/11.0.3/keycloak-11.0.3.tar.gz
+        - source_hash: sha1=87bae7fd63b49756f54e4e293fb37329f117e30d
     cmd.run:
         - name: |
             cd /srv/
             tar -x -z -f /tmp/keycloak.tar.gz -C /srv
-            ln -s keycloak-11.0.0 keycloak
+            ln -s keycloak-11.0.3 keycloak
         - user: root
         - group: root
 


### PR DESCRIPTION
Upgrading Keycloak allowed the server to auth update the database.  I will like the fixes between the two versions.  Some were flagged as critical.

https://issues.redhat.com/browse/KEYCLOAK-16299?jql=project%20%3D%20KEYCLOAK%20AND%20fixVersion%20in%20(11.0.1%2C%2011.0.2%2C%2011.0.3)
