### PR TITLE
Scale Stack fix

### DIFF
--- a/bin/scale_stack.py
+++ b/bin/scale_stack.py
@@ -36,15 +36,13 @@ Order of scaling down:
 import boto3
 import time
 import alter_path
-from botocore.exceptions import ClientError
 from lib import configuration
 
 PRODUCTION = ["bossdb.boss"]
 
 def scale_stack(args):
     if args.bosslet_name in PRODUCTION:
-        print("ERROR: Cannot scale down production environment.")
-        return
+        raise Exception("Cannot scale down production environment.")
     
     session = args.bosslet_config.session
     


### PR DESCRIPTION
Fixes issue in the scale stack utility where endpoint would start before vault or bastion and cause issues. Enforces order of operations and waits for instances to start before starting the next dependent. 