### PR TITLE
Use pip to install `ndingest`.

### DIFF
--- a/cloud_formation/lambda/multi_lambda/lambda.yml
+++ b/cloud_formation/lambda/multi_lambda/lambda.yml
@@ -1,5 +1,5 @@
 name: multilambda
-runtime: python3.7
+runtime: python3.8
 include:
         # DP NOTE: The spdb and heaviside repositories are copied into repos/
         #          where pip can install them from
@@ -8,7 +8,7 @@ include:
         salt_stack/salt/boss-tools/files/boss-tools.git/cloudwatchwrapper: cloudwatchwrapper
         salt_stack/salt/boss-tools/files/boss-tools.git/lambda: lambda
         salt_stack/salt/boss-tools/files/boss-tools.git/lambdautils: lambdautils
-        salt_stack/salt/ndingest/files/ndingest.git: ndingest
+        salt_stack/salt/ndingest/files/ndingest.git: repos/ndingest
         lib/heaviside.git: repos/heaviside
         lib/heaviside.git/requirements.txt: heaviside/requirements.txt
         lib/names.py: bossnames/names.py
@@ -31,9 +31,14 @@ system_packages:
         - gcc-c++
 python_packages:
         - repos/spdb/
+        - repos/ndingest/
         - repos/heaviside/
 manual_commands:
         - |
+                # Copy settings file for ndingest
+                cp repos/ndingest/ndingest/settings/settings.ini ./ndingest/settings
+        - |
+ 
                 # Remove repositories used to do install
                 rm -rf repos/
         - | # Should this be a manual command or a list of files to be copied into the staging directory

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -76,7 +76,7 @@ SALT_DIR = repo_path('salt_stack', 'salt')
 
 DYNAMO_METADATA_SCHEMA = SALT_DIR + '/boss/files/boss.git/django/bosscore/dynamo_schema.json'
 DYNAMO_S3_INDEX_SCHEMA = SALT_DIR + '/spdb/files/spdb.git/spdb/spatialdb/dynamo/s3_index_table.json'
-DYNAMO_TILE_INDEX_SCHEMA  = SALT_DIR + '/ndingest/files/ndingest.git/nddynamo/schemas/boss_tile_index.json'
+DYNAMO_TILE_INDEX_SCHEMA  = SALT_DIR + '/ndingest/files/ndingest.git/ndingest/nddynamo/schemas/boss_tile_index.json'
 # Max number to append to task id attribute of tile index (used to prevent hot
 # partitions when writing to the task_id_index GSI).
 MAX_TASK_ID_SUFFIX = 100

--- a/lib/lambdas.py
+++ b/lib/lambdas.py
@@ -22,17 +22,12 @@ from lib import console
 import botocore
 import configparser
 import yaml
-import glob
 import os
 import tempfile
-import subprocess
-import shlex
-import shutil
-import pwd
 import pathlib
 
 # Location of settings files for ndingest.
-NDINGEST_SETTINGS_FOLDER = const.repo_path('salt_stack', 'salt', 'ndingest', 'files', 'ndingest.git', 'settings')
+NDINGEST_SETTINGS_FOLDER = const.repo_path('salt_stack', 'salt', 'ndingest', 'files', 'ndingest.git', 'ndingest', 'settings')
 
 # Template used for ndingest settings.ini generation.
 NDINGEST_SETTINGS_TEMPLATE = NDINGEST_SETTINGS_FOLDER + '/settings.ini.apl'
@@ -189,7 +184,6 @@ def update_lambda_code(bosslet_config):
     Args:
         bosslet_config: Bosslet configuration object
     """
-    names = bosslet_config.names
     uses_multilambda = [k for k, v in lambda_dirs(bosslet_config).items()
                           if v == 'multi_lambda']
     config = load_lambda_config('multi_lambda')
@@ -242,9 +236,9 @@ def load_lambdas_on_s3(bosslet_config, lambda_name = None, lambda_dir = None):
             console.error("Cannot build a lambda that doesn't use a code zip file")
             return None
 
-    # To prevent rubuilding a lambda code zip multiple times during an individual execution memorize what has been built
+    # To prevent rebuilding a lambda code zip multiple times during an individual execution memorize what has been built
     if lambda_dir in BUILT_ZIPS:
-        console.debug('Lambda code {} has already be build recently, skipping...'.format(lambda_dir))
+        console.debug('Lambda code {} already built recently, skipping...'.format(lambda_dir))
         return
     BUILT_ZIPS.append(lambda_dir)
 

--- a/salt_stack/salt/lambda-dev/files/build_lambda.py
+++ b/salt_stack/salt/lambda-dev/files/build_lambda.py
@@ -16,12 +16,12 @@
 import os
 import sys
 import time
-import glob
 import zipfile
 import shlex
 import shutil
 import subprocess
 import pathlib
+import importlib
 
 
 
@@ -53,7 +53,6 @@ def create_layer(bucket, target_name, description):
         target_name (string): Name to give the zip_File in S3
         description (string): Metadata to attach to the file
     """
-    session = boto3.session.Session()
     layer_name = target_name[:-4].replace('.', '-') # remove the `.zip`
     
     client = boto3.session.Session().client('lambda')
@@ -210,6 +209,11 @@ if __name__ == '__main__':
     #          running the script again (after the packages have been
     #          installed) normally works
     run('python3 -m pip install --user boto3 PyYaml')
+
+    # If the above packages were just installed, this makes sure we can import
+    # while still running.
+    importlib.invalidate_caches()
+
     import boto3
     import yaml
 

--- a/salt_stack/salt/ndingest/build_settings.py
+++ b/salt_stack/salt/ndingest/build_settings.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,53 +16,7 @@
 Generate the settings.ini for ndingest after bootup.
 """
 
-import json
-import configparser
-import urllib.request
-from spdb.c_lib.ndtype import CUBOIDSIZE
-
-# Location of settings files for ndingest.
-NDINGEST_SETTINGS_FOLDER = '/usr/local/lib/python3.8/dist-packages/ndingest/settings'
-
-# Template used for ndingest settings.ini generation.
-NDINGEST_SETTINGS_TEMPLATE = NDINGEST_SETTINGS_FOLDER + '/settings.ini.apl'
-
-BOSS_CONFIG = '/etc/boss/boss.config'
-
-def get_region():
-    url = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
-    doc = urllib.request.urlopen(url).read().decode('utf-8')
-    doc = json.loads(doc)
-    return doc['region']
-
-def create_settings(tmpl_fp, boss_fp):
-    """
-    Args:
-        tmpl_fp (file-like object): ndingest settings.ini template.
-        boss_fp (file-like object): Boss config.
-    """
-    boss_config = configparser.ConfigParser()
-    boss_config.read_file(boss_fp)
-
-    nd_config = configparser.ConfigParser()
-    nd_config.read_file(tmpl_fp)
-
-    nd_config['boss']['domain'] = boss_config['system']['fqdn'].split('.', 1)[1]
-
-    nd_config['aws']['region'] = get_region()
-    nd_config['aws']['tile_bucket'] = boss_config['aws']['tile_bucket']
-    nd_config['aws']['cuboid_bucket'] = boss_config['aws']['cuboid_bucket']
-    nd_config['aws']['tile_index_table'] = boss_config['aws']['tile-index-table']
-    nd_config['aws']['cuboid_index_table'] = boss_config['aws']['s3-index-table']
-    nd_config['aws']['max_task_id_suffix'] = boss_config['aws']['max_task_id_suffix']
-
-    nd_config['spdb']['SUPER_CUBOID_SIZE'] = ', '.join(str(x) for x in CUBOIDSIZE[0])
-
-    with open(NDINGEST_SETTINGS_FOLDER + '/settings.ini', 'w') as out:
-        nd_config.write(out)
+from ndingest.settings.boss_build_settings import run
 
 if __name__ == '__main__':
-    with open(NDINGEST_SETTINGS_TEMPLATE) as nd_tmpl:
-        with open(BOSS_CONFIG) as boss_cfg:
-            create_settings(nd_tmpl, boss_cfg)
-
+    run()

--- a/salt_stack/salt/ndingest/init.sls
+++ b/salt_stack/salt/ndingest/init.sls
@@ -4,14 +4,9 @@ include:
     - spdb
 
 ndingest-lib:
-    file.recurse:
-        - name: /usr/local/lib/python3.8/dist-packages/ndingest
-        - source: salt://ndingest/files/ndingest.git
-        - include_empty: true
-        - user: root
-        - group: root
-        - file_mode: 755
-        - dir_mode: 755
+    pip.installed:
+        # DP HACK: Cannot use salt:// with pip.installed, so assume the base directory
+        - name: /srv/salt/ndingest/files/ndingest.git/
         - require:
             - sls: python.python3
 


### PR DESCRIPTION
Using pip ensures `ndingest` gets installed to the proper location.
Manually copying the files with SaltStack made us prone to break if
something changed with the Ubuntu AMI such as when their Python version
changes and the package folder location moves.

Ran an ingest regression test to check for breaking changes.

## Related PR:
https://github.com/jhuapl-boss/ndingest/pull/14