### PR TITLE
Use stack name in name of cuboid queue export.

### DIFF
--- a/cloud_formation/configs/api.py
+++ b/cloud_formation/configs/api.py
@@ -144,7 +144,7 @@ def create_config(bosslet_config, db_config={}):
     # Queue that holds S3 object keys of cuboids to be indexed.
     config.add_sqs_queue(names.index_cuboids_keys.sqs, names.index_cuboids_keys.sqs, 120, 20160)
     config.add_output(names.index_cuboids_keys.sqs, {"Fn::GetAtt": [names.index_cuboids_keys.sqs, 'Arn']},
-                      const.CUBOID_KEYS_SQS_ARN, 'Arn of cuboid keys SQS queue used for object indexing')
+                      names.index_cuboids_keys.sqs, 'Arn of cuboid keys SQS queue used for object indexing')
 
     config.add_sqs_queue(names.deadletter.sqs, names.deadletter.sqs, 30, 20160)
 

--- a/cloud_formation/configs/idindexing.py
+++ b/cloud_formation/configs/idindexing.py
@@ -105,7 +105,7 @@ def create_config(bosslet_config):
     ids_queue_arn = {"Fn::GetAtt": [names.index_ids_queue.sqs, 'Arn']}
     config.add_lambda_event_source('startIndexIdWriter', ids_queue_arn, names.start_sfn.lambda_, 1)
 
-    cuboid_queue_arn = {"Fn::ImportValue": const.CUBOID_KEYS_SQS_ARN}
+    cuboid_queue_arn = {"Fn::ImportValue": names.index_cuboids_keys.sqs}
     config.add_lambda_event_source('startCuboidSupervisor', cuboid_queue_arn, names.start_sfn.lambda_, 1)
 
     return config

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -70,11 +70,6 @@ DOWNSAMPLE_DLQ_LAMBDA = LAMBDA_DIR + '/downsample/dlq.py'
 DELETE_ENI_LAMBDA = LAMBDA_DIR + '/delete-eni/delete_eni.py'
 
 
-#################################
-# CloudFormation Template Outputs
-CUBOID_KEYS_SQS_ARN = 'indexCuboidKeysSqsArn'
-
-
 ########################
 # DynamoDB Table Schemas
 SALT_DIR = repo_path('salt_stack', 'salt')


### PR DESCRIPTION
For the test stack, where we have multiple Boss instances, we need a
unique name when exporting the arn of the cuboid keys queue from the
api config.

Make the name unique by using the same name provided by lib/names.py.