### PR TITLE
Revert lambda python to 3.7.

### DIFF
--- a/cloud_formation/lambda/multi_lambda/lambda.yml
+++ b/cloud_formation/lambda/multi_lambda/lambda.yml
@@ -1,5 +1,5 @@
 name: multilambda
-runtime: python3.8
+runtime: python3.7
 include:
         # DP NOTE: The spdb and heaviside repositories are copied into repos/
         #          where pip can install them from


### PR DESCRIPTION
Any changes to the lambda python version must also be done in
conjunction with changing the python version used by the lambda build
server: `salt_stack/salt/lambda-dev/init.sls`