### PR TITLE
Add s3:ListBucket permission to cuboid import role

### DIFF
--- a/cloud_formation/configs/cachedb.py
+++ b/cloud_formation/configs/cachedb.py
@@ -260,6 +260,9 @@ def create_config(bosslet_config, user_data=None):
         "ingestBucketPolicy", ingest_bucket_name,
         ['s3:GetObject', 's3:PutObject', 's3:PutObjectTagging'],
         { 'AWS': cuboid_import_role})
+    config.append_s3_bucket_policy(
+        "ingestBucketPolicy", ingest_bucket_name,
+        ['s3:ListBucket'], { 'AWS': cuboid_import_role}, bucket_only=True)
 
     config.add_ec2_instance("CacheManager",
                             names.cachemanager.dns,


### PR DESCRIPTION
Let the cuboid import lambda list the contents of a bucket so it can
handle errors properly when the cuboid was deleted from the bucket.
Without this permission, it would get an Access Denied Error when trying
to get the cuboid's metadata or invoke the copy operation.

The cuboid could be deleted by another invocation of the lambda.

Updated add_s3_bucket_policy() and append_s3_bucket_policy() so that
actions such as s3:ListBucket can be specified (must only specify the
bucket, not <bucket>/* because it operates on the bucket, not the
bucket's objects).

## Related PR

https://github.com/jhuapl-boss/boss-tools/pull/58