### PR TITLE
Update complete sfn to support volumetric ingests.

### DIFF
--- a/cloud_formation/stepfunctions/complete_ingest.hsd
+++ b/cloud_formation/stepfunctions/complete_ingest.hsd
@@ -22,30 +22,34 @@ Args:
     }
 """
 
-Activity('ScanForMissingChunks')
-    """Look for missing chunks from the ingest.
+if '$.job.ingest_type' == 0:
+    """IfTileIngest"""
 
-    Scans the tile index in DynamoDB for any chunks that have missing tiles.  If
-    tiles are missing, they are placed back in the upload queue for that ingest
-    job.
+    Activity('ScanForMissingChunks')
+        """Look for missing chunks from the ingest.
 
-    boss-tools/activities/scan_for_missing_chunks.py
-    """
-    retry ['KeyError'] 1 0 1.0
-    retry [] 60 3 2.5
+        Scans the tile index in DynamoDB for any chunks that have missing tiles.  If
+        tiles are missing, they are placed back in the upload queue for that ingest
+        job.
 
-if '$.quit' == False:
-    """If no missing tiles found, clean up the ingest.
-    """
-
-    Activity('IngestCleaner')
-        """Clean up ingest job's AWS resources.
-
-        Deletes all SQS queues used for the ingest.
-        Deletes AWS credentials created for the ingest.
-        Marks the ingest job as complete.
-
-        boss-tools/activities/cleanup_ingest.py
+        boss-tools/activities/scan_for_missing_chunks.py
         """
         retry ['KeyError'] 1 0 1.0
         retry [] 60 3 2.5
+
+    if '$.quit' == True:
+        """IfQuitFoundMissingChunks"""
+        Success()
+            """StopFoundMissingChunks"""
+
+Activity('IngestCleaner')
+    """Clean up ingest job's AWS resources.
+
+    Deletes all SQS queues used for the ingest.
+    Deletes AWS credentials created for the ingest.
+    Marks the ingest job as complete.
+
+    boss-tools/activities/cleanup_ingest.py
+    """
+    retry ['KeyError'] 1 0 1.0
+    retry [] 60 3 2.5


### PR DESCRIPTION
Previously the complete step function only supported completing tile ingests.

Tested with a small volumetric ingest and the (tile) ingest regression test.

### Related PR:
https://github.com/jhuapl-boss/boss/pull/103

Screenshot shows the step function execution path for a volumetric ingest:
<img width="618" alt="Screen Shot 2022-01-11 at 5 04 22 PM" src="https://user-images.githubusercontent.com/7428355/149028680-45d43699-eb1d-4d25-8601-3e4317bead0b.png">

