### PR TITLE
Always use Docker to build lambdas

### DIFF
--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -13,7 +13,7 @@ from the root directory of the cloned boss-manage.git repository.*
 
 ### Workstation
 You will need a machine installed with the following software packages:
-* Python 3.7 or later
+* Python 3.8 or later
   - The Boss Manage software can be run within `venv`, `virtualenv`, or `virtualenvwrapper`
 * Packer 1.8.x ([download](https://www.packer.io/)) (add it to your path or in the `boss-manage.git/bin/` directory)
 * Docker Desktop ([download](https://docs.docker.com/desktop/release-notes/))

--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -15,23 +15,14 @@ from the root directory of the cloned boss-manage.git repository.*
 You will need a machine installed with the following software packages:
 * Python 3.7 or later
   - The Boss Manage software can be run within `venv`, `virtualenv`, or `virtualenvwrapper`
-* Packer ([download](https://www.packer.io/)) (add it to your path or in the `boss-manage.git/bin/` directory)
+* Packer 1.8.x ([download](https://www.packer.io/)) (add it to your path or in the `boss-manage.git/bin/` directory)
+* Docker Desktop ([download](https://docs.docker.com/desktop/release-notes/))
+  - Contact your department software representative to get a license
 
 Note: The boss-manage software was developed and tested under Linux and Mac. It has not been tested under Windows, including under Windows Subsystem for Linux.
 
 #### Lambda Build
-There are multiple ways to build the lambda code zip files. The standard way is to use an EC2 instance, but the boss-manage code supports building locally using Docker or directly on the machine running the boss-manage code
-
-Requirements for Docker:
-* Docker or Docker CLI compatible container environment (like Podman)
-* Set the environment variable `LAMBDA_BUILD_CONTAINER` to the name of the container command
-  - `export LAMBDA_BUILD_CONTAINER=docker`
-  - Or in the Bosslet config `os.environ['LAMBDA_BUILD_CONTAINER'] = 'docker'`
-
-Requirements for Local Machine:
-* NodeJS ([download](https://nodejs.org/en/download/)) Version 10.X
-* Yum package manager
-  - Lambdas run on Amazon Linux, which is a Red Hat derivative distribution
+Boss builds lambdas via a Docker container.
 
 ## Clone Repositories
 You will need access to the following code repositories on Github:

--- a/docs/Onboarding.md
+++ b/docs/Onboarding.md
@@ -7,7 +7,7 @@ A new team member will need to provide them access to the following:
 2. Access to the [APL Microns](https://github.com/aplmicrons) repository. The new user will need a bosslet config created and the ability to download the bosslet-configs project.
 3. Access to the [JHUAPL Boss](https://github.com/jhuapl-boss) repository to pull and make code commits.  This is done by adding the individual to our dev team 
 
-# Development Envrionment
+# Development Environment
 The [Installation Guide](./InstallGuide.md) is geared to installing BossDB in new AWS subscription. It covers many of the topics you won't need to get into right now. This **onboarding guide** will highlight what you need to do to get up and running quickly.  However any Python virtual environment may be used, so used whatever you are comfortable using.
 
 ## Choose your Python Distribution
@@ -124,7 +124,4 @@ Open the secrets.txt file and find the password for **bossadmin** account. An ex
 Use your browser to navigate to your instance of the boss UI. The url will look something like this: https://api-wilsopw1.thebossdev.io/. You will need to replace wilsopw1 with your 5-2-1. 
 
 You should be redirected to the keycloak login page. Enter **bossadmin** as the username and use the password retrieved from vault.
-
-
-
 

--- a/lib/hash.py
+++ b/lib/hash.py
@@ -1,0 +1,29 @@
+class FilesHash:
+    def __init__(self, hash_alg):
+        """
+        Constructor.
+
+        Args:
+            hash: A hash algorithm from the hashlib standard library.
+        """
+        self.hash = hash_alg
+
+    @property
+    def hexdigest(self) -> str:
+        """
+        Returns:
+            Hexidecimal hash of all given files.
+        """
+        return self.hash.hexdigest()
+
+    def add_file(self, path) -> None:
+        """
+        Opens the given file and hashes it contents for inclusion in the
+        overall hash.
+        """
+        try:
+            with open(path, 'rb') as f:
+                data = f.read()
+            self.hash.update(data)
+        except IsADirectoryError:
+            pass

--- a/lib/zip.py
+++ b/lib/zip.py
@@ -20,7 +20,7 @@ def zip_directory(directory, name = "lambda"):
     target = os.path.join(tempfile.mkdtemp(), name)
     return shutil.make_archive(target, "zip", directory, directory)
 
-def write_zip_file(full_path, zipfile_instance, arcname=None):
+def write_zip_file(full_path, zipfile_instance, arcname=None, callback=None):
     """
     Writes the directory, file or symbolic link using the zipfile instance
     works with write_to_zip()
@@ -28,6 +28,7 @@ def write_zip_file(full_path, zipfile_instance, arcname=None):
         full_path:  full path to file, dir or symlink
         zipfile_instance: instance of a zipfile created with w or a
         arcname: Name to give the file or directory in the zip archive
+        callback: Optional callback function that's passed the path of each file
 
     Returns:
 
@@ -35,6 +36,7 @@ def write_zip_file(full_path, zipfile_instance, arcname=None):
     if arcname is None:
         arcname = full_path
 
+    callback(full_path)
     if os.path.islink(full_path):
         # based on http://www.mail-archive.com/python-list@python.org/msg34223.html
         zip_info = zipfile.ZipInfo(arcname)
@@ -46,14 +48,15 @@ def write_zip_file(full_path, zipfile_instance, arcname=None):
         zipfile_instance.write(full_path, arcname)
 
 
-def write_to_zip(path, zippath, append=True, arcname=None):
+def write_to_zip(path, zippath, append=True, arcname=None, callback=None):
     """
     will add a file, directory or symlink to a zip file.
     Args:
         path: path to file to be zipped.
         zippath: path to the zip file to be created or added to.
         append: if True write in append mode else create a new file.
-        arcname: Name to give the file or directory in the zip archive
+        arcname: Name to give the file or directory in the zip archive.
+        callback: Optional callback function that's passed the path of each file.
 
     Returns:
         None
@@ -72,12 +75,12 @@ def write_to_zip(path, zippath, append=True, arcname=None):
             for d in dirs:
                 dirname = os.path.join(root, d)
                 dstname = os.path.join(dst, d)
-                write_zip_file(dirname, fzip, dstname)
+                write_zip_file(dirname, fzip, dstname, callback=callback)
             for f in files:
                 filename = os.path.join(root, f)
                 dstname = os.path.join(dst, f)
-                write_zip_file(filename, fzip, dstname)
+                write_zip_file(filename, fzip, dstname, callback=callback)
     else:
-        write_zip_file(path, fzip, arcname)
+        write_zip_file(path, fzip, arcname, callback=callback)
     fzip.close()
 

--- a/salt_stack/salt/lambda-dev/files/build.sh
+++ b/salt_stack/salt/lambda-dev/files/build.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
 
-python3 -m pip install boto3 PyYaml
-# domain bucket
-python3 /var/task/build_lambda.py $1 $2
+# This script runs **inside** the Docker lambda build container and builds the
+# lambda(s).  It is invoked by load_lambdas_on_s3() from lib/lambdas.py.
+#
+# Required args:
+#   $1: domain name
+#   $2: S3 bucket name
+#   $3: hash of zip file name
 
+set -euo pipefail
+
+if test "$#" -ne 3; then
+    echo
+    echo "ERROR: $0 - must supply domain, bucket, and hash file names"
+    echo
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Trust the APL Root cert so the container can use https inside of APLNIS.
+cp "${SCRIPT_DIR}/JHUAPL-MS-Root-CA-05-21-2038-B64-text.crt" /etc/pki/ca-trust/source/anchors
+update-ca-trust extract
+
+# Install packages needed by build_lambda.py.
+python3 -m pip install -r "${SCRIPT_DIR}/requirements.txt"
+
+python3 "${SCRIPT_DIR}/build_lambda.py" $1 $2 $3

--- a/salt_stack/salt/lambda-dev/files/requirements.txt
+++ b/salt_stack/salt/lambda-dev/files/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+PyYaml


### PR DESCRIPTION
* Stop using lambda builder server to reduce cost of an always on EC2 instance
* Calculate hash of files for lambda on Docker host during zip file creation time lambda build can be aborted before running Docker container
* Use requirements.txt to install boto3 and PyYaml in build container
* Add Docker to install docs
* Add Packer version to install docs